### PR TITLE
fix: use babili to minify ES6 sources.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ node_js:
 
 script:
 - npm run build
-- COVERAGE=y npm run test-coverage
+- npm run test-coverage
+- echo "RE-RUN all tests on the minified file" && TEST_MINIFIED_POLYFILL=1 npm run test
 
 after_script: npm run publish-coverage
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,6 +8,8 @@ const LICENSE = `/* This Source Code Form is subject to the terms of the Mozilla
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */`;
 
+const MINIFIED_FILE_FOOTER = `\n\n// <%= pkg.name %> v.<%= pkg.version %> (<%= pkg.homepage %>)\n\n${LICENSE}`;
+
 module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON("package.json"),
@@ -55,33 +57,25 @@ module.exports = function(grunt) {
       },
     },
 
-    "closure-compiler": {
-      dist: {
-        files: {
-          "dist/browser-polyfill.min.js": ["dist/browser-polyfill.js"],
-        },
+    babel: {
+      minify: {
         options: {
-          // Closure currently supports only whitespace and comment stripping
-          // when both the input and output languages are ES6.
-          compilation_level: "WHITESPACE_ONLY",
-          language_in: "ECMASCRIPT6_STRICT",
-          language_out: "ECMASCRIPT6",
-          output_wrapper: `${LICENSE}\n%output%`,
+          babelrc: false,
+          comments: false,
+          presets: ["babili"],
+          sourceMap: true,
+        },
+        files: {
+          "dist/browser-polyfill.min.js": "dist/browser-polyfill.js",
         },
       },
     },
 
-    // This currently does not support ES6 classes.
-    uglify: {
-      options: {
-        banner: LICENSE,
-        compress: true,
-      },
-
-      dist: {
-        files: {
-          "dist/browser-polyfill.min.js": ["dist/browser-polyfill.js"],
-        },
+    concat: {
+      license: {
+        src: "dist/browser-polyfill.min.js",
+        dest: "dist/browser-polyfill.min.js",
+        options: {footer: MINIFIED_FILE_FOOTER},
       },
     },
   });
@@ -89,7 +83,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks("gruntify-eslint");
   grunt.loadNpmTasks("grunt-replace");
   grunt.loadNpmTasks("grunt-coveralls");
-  require("google-closure-compiler").grunt(grunt);
+  grunt.loadNpmTasks("grunt-contrib-concat");
+  grunt.loadNpmTasks("grunt-babel");
 
-  grunt.registerTask("default", ["eslint", "replace", "closure-compiler"]);
+  grunt.registerTask("default", ["eslint", "replace", "babel:minify", "concat:license"]);
 };

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
   },
   "homepage": "https://github.com/mozilla/webextension-polyfill",
   "devDependencies": {
+    "babel-preset-babili": "0.0.10",
     "chai": "^3.5.0",
-    "google-closure-compiler": "^20160911.0.0",
+    "eslint": "3.9.1",
     "grunt": "^1.0.1",
+    "grunt-babel": "^6.0.0",
+    "grunt-contrib-concat": "^1.0.1",
     "grunt-coveralls": "^1.0.1",
     "grunt-replace": "*",
     "gruntify-eslint": "*",
-    "eslint": "3.9.1",
     "istanbul-lib-instrument": "^1.1.3",
     "jsdom": "^9.6.0",
     "mocha": "^3.1.0",
@@ -27,7 +29,11 @@
     "sinon": "^1.17.6"
   },
   "nyc": {
-    "reporter": ["lcov", "text", "html"],
+    "reporter": [
+      "lcov",
+      "text",
+      "html"
+    ],
     "instrument": false
   },
   "scripts": {

--- a/test/setup.js
+++ b/test/setup.js
@@ -13,7 +13,8 @@ if (process.env.ENABLE_JSDOM_CONSOLE == "y") {
 
 // Path to the browser-polyfill script, relative to the current work dir
 // where mocha is executed.
-const BROWSER_POLYFILL_PATH = "./dist/browser-polyfill.js";
+const BROWSER_POLYFILL_PATH = process.env.TEST_MINIFIED_POLYFILL ?
+  "./dist/browser-polyfill.min.js" : "./dist/browser-polyfill.js";
 
 // Create the jsdom window used to run the tests
 const testDOMWindow = jsdom("", {virtualConsole}).defaultView;


### PR DESCRIPTION
This PR introduces the changes needed to use [babili](https://github.com/babel/babili) instead of google-closure-compiler to generate the minified version of the original ES6 sources.

The goal of this PR is producing a minified version of the `webextension-polyfill` sources that can be loaded successfully on Chrome (instead of raising a "SyntaxError" exception as described in #10) 