### PR TITLE
Remove pageAction.show and .hide from API metadata

### DIFF
--- a/api-metadata.json
+++ b/api-metadata.json
@@ -278,17 +278,9 @@
       "minArgs": 1,
       "maxArgs": 1
     },
-    "hide": {
-      "minArgs": 0,
-      "maxArgs": 0
-    },
     "setIcon": {
       "minArgs": 1,
       "maxArgs": 1
-    },
-    "show": {
-      "minArgs": 0,
-      "maxArgs": 0
     }
   },
   "runtime": {


### PR DESCRIPTION
Their presence there caused them to be wrapped as asynchronous functions. It caused Promise's resolve function to be passed to them, which generated error (`Invocation of form pageAction.show(function) doesn't match definition pageAction.show(integer tabId)`).

This is a response to PR #9.