### PR TITLE
Force line endings to LF for js files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Let git decide for most files
+* text=auto
+
+# Specify line ending for js files
+**/*.js text eol=lf


### PR DESCRIPTION
Fixes build on windows by allowing ESLINT to pass when core.autolf is set to anything other than forcing LF (as is the default for windows).

Fixes issue #14 