### PR TITLE
test: add linting to test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
   },
   "scripts": {
     "build": "grunt",
+    "pretest": "grunt eslint",
     "test": "mocha",
-    "test-coverage": "COVERAGE=y nyc mocha",
+    "test-coverage": "COVERAGE=y nyc npm test",
     "publish-coverage": "grunt coveralls"
   }
 }


### PR DESCRIPTION
Making `grunt eslint` the `pretest` script causes it to run as part of
`npm test`. Likewise, making the `test-coverage` script run `npm test`
(instead of running `mocha` directly) ensures that the Travis builds
will run eslint as well.