### PR TITLE
style: normalize package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   "homepage": "https://github.com/mozilla/webextension-polyfill",
   "devDependencies": {
     "chai": "^3.5.0",
+    "eslint": "3.9.1",
     "google-closure-compiler": "^20160911.0.0",
     "grunt": "^1.0.1",
     "grunt-coveralls": "^1.0.1",
     "grunt-replace": "*",
     "gruntify-eslint": "*",
-    "eslint": "3.9.1",
     "istanbul-lib-instrument": "^1.1.3",
     "jsdom": "^9.6.0",
     "mocha": "^3.1.0",
@@ -27,7 +27,11 @@
     "sinon": "^1.17.6"
   },
   "nyc": {
-    "reporter": ["lcov", "text", "html"],
+    "reporter": [
+      "lcov",
+      "text",
+      "html"
+    ],
     "instrument": false
   },
   "scripts": {


### PR DESCRIPTION
When running `npm install` to add new `devDependencies`, `npm` reformats
package.json with these changes, as can be seen [here]. Making these
changes separately allows developers to more easily keep them out of
unrelated commits.

[here]: https://github.com/mozilla/webextension-polyfill/pull/11/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L22