### PR TITLE
Support sendResponse callback in onMessage

### DIFF
--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -312,7 +312,16 @@ if (typeof browser === "undefined") {
        *        yield a response. False otherwise.
        */
       return function onMessage(message, sender, sendResponse) {
-        let result = listener(message, sender);
+        let didCallSendResponse = false;
+        let result = listener(message, sender, function(result) {
+          // Note: No need to check for duplicate calls. The browser environment
+          // should take care of reporting errors if necessary.
+          didCallSendResponse = true;
+          sendResponse(result);
+        });
+        if (didCallSendResponse || result === true) {
+          return result;
+        }
 
         if (isThenable(result)) {
           result.then(sendResponse, error => {


### PR DESCRIPTION
Now onMessage behaves as documented in MDN, and like Firefox.

The only thing I was not completely sure about is what to do when `return true` is used. It can be resolved in two ways:

1. Calling `sendResponse` with `true`.
2. Returning `true` in the real `onMessage` handler and allowing `sendResponse` to be called asynchronously.

I follow Firefox's implementation and do the latter - http://searchfox.org/mozilla-central/rev/848c29538ab007fb95dc6cff194f0e3d3809613d/toolkit/components/extensions/ExtensionChild.jsm#363

This fixes #16.