### PR TITLE
Support multiple runtime.onMessage listeners that do not return results

### DIFF
--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -315,7 +315,11 @@ if (typeof browser === "undefined") {
         let result = listener(message, sender);
 
         if (isThenable(result)) {
-          result.then(sendResponse, error => {
+          result.then(promiseResult => {
+            if (promiseResult !== undefined) {
+              sendResponse(promiseResult);
+            }
+          }, error => {
             console.error(error);
             sendResponse(error);
           });


### PR DESCRIPTION
When multiple listeners are setup, if they are both async or return promises but those promises do not actually return something when resolved, it will throw the following:

> Cannot send a response more than once per chrome.runtime.onMessage listener per document (message was sent by extensionoegnngioepgemfkdgnfhmlaohjkddmlb).

This should be able to be reproduced as follows:

```
async function handle() {
    await somethingElse();
}
browser.runtime.onMessage.addListener(handle);
browser.runtime.onMessage.addListener(handle);
```

The listeners should not call sendResponse if there is no result from a promise.