### PR TITLE
fix: add missing api metadata for contextMenus.create

### DIFF
--- a/api-metadata.json
+++ b/api-metadata.json
@@ -100,6 +100,10 @@
     }
   },
   "contextMenus": {
+    "create": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
     "update": {
       "minArgs": 2,
       "maxArgs": 2


### PR DESCRIPTION
The [definition for `contextMenus.create(object createProperties, function callback)`](https://developer.chrome.com/extensions/contextMenus#method-create) was missing in the API metadata file. This lead to it to not be wrapped properly, causing crashes when expected to return a promise.