### PR TITLE
UMD wrapper doesn't work with webpack

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,7 +30,7 @@ module.exports = function(grunt) {
         options: {
           patterns: [
             {
-              match: /\{\/\* include\("(.*?)"\) \*\/\}/,
+              match: /require\("..\/(.*?)"\)/,
               replacement: (match, filename) => {
                 return grunt.file.read(filename)
                             .replace(/\n$/, "")

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "webextension-polyfill",
   "version": "0.1.0",
   "description": "A lightweight polyfill library for Promise-based WebExtension APIs in Chrome.",
-  "main": "dist/browser-polyfill.js",
+  "main": "src/browser-polyfill.js",
   "files": [
+    "api-metadata.json",
+    "src",
     "dist"
   ],
   "repository": {

--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -13,10 +13,9 @@ if (typeof browser === "undefined") {
   // never actually need to be called, this allows the polyfill to be included
   // in Firefox nearly for free.
   const wrapAPIs = () => {
-    // NOTE: apiMetadata is associated to the content of the api-metadata.json file
-    // at build time by replacing the following "include" with the content of the
-    // JSON file.
-    const apiMetadata = {/* include("api-metadata.json") */};
+    // Note that `require` does NOT work in general. See discussion here:
+    // https://github.com/mozilla/webextension-polyfill/pull/17#discussion_r99170958
+    const apiMetadata = require("../api-metadata.json"); // eslint-disable-line no-undef
 
     if (Object.keys(apiMetadata).length === 0) {
       throw new Error("api-metadata.json has not been included in browser-polyfill");


### PR DESCRIPTION
On the current master branch (96cfb9c), the following test illustrates the issue:

```bash
npm install --global webpack
npm run build
echo "console.log(require('./'))" > t.js
webpack t.js w.js
node w.js
```

This patch partially reverts 31d778c in order to support webpack.

On my machine, here's the test case output before this patch:

    /Users/josephfrazier/workspace/webextension-polyfill/w.js:75
	    module.exports = factory(!(function webpackMissingModule() { var e = new Error("Cannot find module \".\""); e.code = 'MODULE_NOT_FOUND'; throw e; }()), exports, module);
																		     ^

    Error: Cannot find module "."
	at webpackMissingModule (/Users/josephfrazier/workspace/webextension-polyfill/w.js:75:78)
	at apiMetadata.alarms.clear.minArgs (/Users/josephfrazier/workspace/webextension-polyfill/w.js:75:156)
	at Object.<anonymous> (/Users/josephfrazier/workspace/webextension-polyfill/w.js:89:2)
	at Object.module.exports.module.deprecate (/Users/josephfrazier/workspace/webextension-polyfill/w.js:956:30)
	at __webpack_require__ (/Users/josephfrazier/workspace/webextension-polyfill/w.js:20:30)
	at Object.<anonymous> (/Users/josephfrazier/workspace/webextension-polyfill/w.js:1002:13)
	at __webpack_require__ (/Users/josephfrazier/workspace/webextension-polyfill/w.js:20:30)
	at /Users/josephfrazier/workspace/webextension-polyfill/w.js:66:18
	at Object.<anonymous> (/Users/josephfrazier/workspace/webextension-polyfill/w.js:69:10)
	at Module._compile (module.js:571:32)

And here's the output after:

    /Users/josephfrazier/workspace/webextension-polyfill/w.js:415
	return wrapObject(chrome, staticWrappers, apiMetadata);
			  ^

    ReferenceError: chrome is not defined
	at wrapAPIs (/Users/josephfrazier/workspace/webextension-polyfill/w.js:415:23)
	at Object.module.exports.alarms.clear.minArgs (/Users/josephfrazier/workspace/webextension-polyfill/w.js:420:20)
	at __webpack_require__ (/Users/josephfrazier/workspace/webextension-polyfill/w.js:20:30)
	at Object.<anonymous> (/Users/josephfrazier/workspace/webextension-polyfill/w.js:947:13)
	at __webpack_require__ (/Users/josephfrazier/workspace/webextension-polyfill/w.js:20:30)
	at /Users/josephfrazier/workspace/webextension-polyfill/w.js:66:18
	at Object.<anonymous> (/Users/josephfrazier/workspace/webextension-polyfill/w.js:69:10)
	at Module._compile (module.js:571:32)
	at Object.Module._extensions..js (module.js:580:10)
	at Module.load (module.js:488:32)

Note that this second error is expected, since Node doesn't provide the `chrome` global. The code in `w.js` can be pasted into a browser, where it works correctly.

Related issues:
* https://github.com/mozilla/webextension-polyfill/pull/17/files/af4da3151068a06d30a16d0ec8049f2b02990ae0#diff-a8dc0200482fd536ca439ed8bcf763c2
* https://github.com/mozilla/webextension-polyfill/issues/32