### PR TITLE
feat: add identity.launchWebAuthFlow() in metadata.

### DIFF
--- a/api-metadata.json
+++ b/api-metadata.json
@@ -223,6 +223,12 @@
       "maxArgs": 0
     }
   },
+  "identity": {
+    "launchWebAuthFlow": {
+      "minArgs": 1,
+      "maxArgs": 1
+    }
+  },
   "idle": {
     "queryState": {
       "minArgs": 1,


### PR DESCRIPTION
_Promisify_ the [`browser.identity.launchWebAuthFlow()`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/identity/launchWebAuthFlow) function (available since _Firefox 53_).