### PR TITLE
Handle the browsers which don't support promises (eg. Edge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/*
 ## code coverage
 coverage/
 .nyc_output/
+/.project
+/dist/
+/node_modules/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,9 +32,7 @@ module.exports = function(grunt) {
             {
               match: /\{\/\* include\("(.*?)"\) \*\/\}/,
               replacement: (match, filename) => {
-                return grunt.file.read(filename)
-                            .replace(/\n$/, "")
-                            .replace(/^[^{]/gm, "    $&");
+                return grunt.file.read(filename).replace(/\n$/, "").replace(/^[^{]/gm, "    $&");
               },
             },
             {

--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -14,7 +14,7 @@ try {
 }
 
 if (typeof browser === "undefined" || !_supportsPromises) {
-  var _browser = window.browser || window.msBrowser || window.chrome;
+  var _browser = window.browser || window.msBrowser || window.chrome || browser;
 
   // Wrapping the bulk of this polyfill in a one-time-use function is a minor
   // optimization for Firefox. Since Spidermonkey does not fully parse the

--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -6,7 +6,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-if (typeof browser === "undefined") {
+var _supportsPromises = false;
+try {
+  _supportsPromises = browser.runtime.getPlatformInfo() instanceof Promise;
+} catch (e) {
+}
+
+if (typeof browser === "undefined" || !_supportsPromises) {
+  var browser = window.browser || window.msBrowser || window.chrome;
+
   // Wrapping the bulk of this polyfill in a one-time-use function is a minor
   // optimization for Firefox. Since Spidermonkey does not fully parse the
   // contents of a function until the first time it's called, and since it will
@@ -62,7 +70,7 @@ if (typeof browser === "undefined") {
      * Creates and returns a function which, when called, will resolve or reject
      * the given promise based on how it is called:
      *
-     * - If, when called, `chrome.runtime.lastError` contains a non-null object,
+     * - If, when called, `browser.runtime.lastError` contains a non-null object,
      *   the promise is rejected with that value.
      * - If the function is called with exactly one argument, the promise is
      *   resolved to that value.
@@ -82,8 +90,8 @@ if (typeof browser === "undefined") {
      */
     const makeCallback = promise => {
       return (...callbackArgs) => {
-        if (chrome.runtime.lastError) {
-          promise.reject(chrome.runtime.lastError);
+        if (browser.runtime.lastError) {
+          promise.reject(browser.runtime.lastError);
         } else if (callbackArgs.length === 1) {
           promise.resolve(callbackArgs[0]);
         } else {
@@ -340,7 +348,7 @@ if (typeof browser === "undefined") {
       },
     };
 
-    return wrapObject(chrome, staticWrappers, apiMetadata);
+    return wrapObject(browser, staticWrappers, apiMetadata);
   };
 
   // The build process adds a UMD wrapper around this file, which makes the

--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -10,10 +10,11 @@ var _supportsPromises = false;
 try {
   _supportsPromises = browser.runtime.getPlatformInfo() instanceof Promise;
 } catch (e) {
+  console.log("promises not supported.");
 }
 
 if (typeof browser === "undefined" || !_supportsPromises) {
-  var browser = window.browser || window.msBrowser || window.chrome;
+  var _browser = window.browser || window.msBrowser || window.chrome;
 
   // Wrapping the bulk of this polyfill in a one-time-use function is a minor
   // optimization for Firefox. Since Spidermonkey does not fully parse the
@@ -70,7 +71,7 @@ if (typeof browser === "undefined" || !_supportsPromises) {
      * Creates and returns a function which, when called, will resolve or reject
      * the given promise based on how it is called:
      *
-     * - If, when called, `browser.runtime.lastError` contains a non-null object,
+     * - If, when called, `_browser.runtime.lastError` contains a non-null object,
      *   the promise is rejected with that value.
      * - If the function is called with exactly one argument, the promise is
      *   resolved to that value.
@@ -90,8 +91,8 @@ if (typeof browser === "undefined" || !_supportsPromises) {
      */
     const makeCallback = promise => {
       return (...callbackArgs) => {
-        if (browser.runtime.lastError) {
-          promise.reject(browser.runtime.lastError);
+        if (_browser.runtime.lastError) {
+          promise.reject(_browser.runtime.lastError);
         } else if (callbackArgs.length === 1) {
           promise.resolve(callbackArgs[0]);
         } else {
@@ -348,7 +349,7 @@ if (typeof browser === "undefined" || !_supportsPromises) {
       },
     };
 
-    return wrapObject(browser, staticWrappers, apiMetadata);
+    return wrapObject(_browser, staticWrappers, apiMetadata);
   };
 
   // The build process adds a UMD wrapper around this file, which makes the

--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -250,7 +250,7 @@ if (typeof browser === "undefined" || !_supportsPromises) {
             return value;
           }
 
-          if(!cache[prop]) {
+          if (!cache[prop]) {
             cache[prop] = value;
           }
           return value;

--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -250,7 +250,9 @@ if (typeof browser === "undefined" || !_supportsPromises) {
             return value;
           }
 
-          cache[prop] = value;
+          if(!cache[prop]) {
+            cache[prop] = value;
+          }
           return value;
         },
 


### PR DESCRIPTION
Compatibility with environments that have the browser namespace but do not support promises.

I was inspired by Snoak's answer in the following issue: mozilla#3