### PR TITLE
add more APIs to api-metadata

### DIFF
--- a/api-metadata.json
+++ b/api-metadata.json
@@ -291,6 +291,38 @@
       "maxArgs": 0
     }
   },
+  "permissions": {
+    "contains": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "getAll": {
+      "minArgs": 0,
+      "maxArgs": 0
+    },
+    "remove": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "request": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+  },
+  "privacy": {
+    "services": {
+      "passwordSavingEnabled": {
+        "get": {
+          "minArgs": 1,
+          "maxArgs": 1
+        },
+        "set": {
+          "minArgs": 1,
+          "maxArgs": 1
+        },
+      },
+    },
+  },
   "runtime": {
     "getBackgroundPage": {
       "minArgs": 0,


### PR DESCRIPTION
Adding browser.permissions and browser.privacy.services.passwordSavingEnabled (https://bugzilla.mozilla.org/show_bug.cgi?id=1361364)