### PR TITLE
Limit eslint to the project's own rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "parserOptions": {
     "ecmaVersion": 6,
   },


### PR DESCRIPTION
This is what's shown on my computer:

```
.../webextension-polyfill/src/browser-polyfill.js
  7:1  error  'use strict' is unnecessary inside of modules  strict

.../webextension-polyfill/Gruntfile.js
   3:1  error  'use strict' is unnecessary inside of modules   strict
  36:1  error  Expected indentation of 18 spaces but found 28  indent
  37:1  error  Expected indentation of 18 spaces but found 28  indent
```

* `indent` errors will be fixed by #42
* `strict` errors are due to rules defined in my own `/.eslintrc` and disappear after this PR.
