### PR TITLE
Fix Constructor WeakMap requires 'new'

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,11 @@ module.exports = function(grunt) {
           babelrc: false,
           comments: false,
           presets: ["babili"],
+          plugins: [
+            ["babel-plugin-transform-builtin-extend", {
+              globals: ["WeakMap"],
+            }],
+          ],
           sourceMap: true,
         },
         files: {
@@ -79,6 +84,9 @@ module.exports = function(grunt) {
                 "webextension-polyfill": "browser",
               },
               exactGlobals: true,
+            }],
+            ["babel-plugin-transform-builtin-extend", {
+              globals: ["WeakMap"],
             }],
           ],
           sourceMap: true,

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/mozilla/webextension-polyfill",
   "devDependencies": {
+    "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "babel-preset-babili": "0.0.10",
     "chai": "^3.5.0",


### PR DESCRIPTION
When using this polyfill in Chrome, I'm getting this error:

> Constructor WeakMap requires 'new'

After some google searches, it seems that extending built-in is not supported. This PR adds a babel plugin allowing that.

Also fix #14 

EDIT: Chrome version is 60.0.3112.90, OS is macOS Sierra 10.12.5