### PR TITLE
feat: Add support for wrapping the devtools APIs

### DIFF
--- a/api-metadata.json
+++ b/api-metadata.json
@@ -135,6 +135,21 @@
       "maxArgs": 1
     }
   },
+  "devtools": {
+    "inspectedWindow": {
+      "eval": {
+        "minArgs": 1,
+        "maxArgs": 2
+      }
+    },
+    "panels": {
+      "create": {
+        "minArgs": 3,
+        "maxArgs": 3,
+        "singleCallbackArg": true
+      }
+    }
+  },
   "downloads": {
     "download": {
       "minArgs": 1,


### PR DESCRIPTION
This PR is applying the following changes to fix #56:

- the changes into api-metadata.json, needed to instruct the polyfill to wrap the devtools API namespace)
- a fix in the base browser-polyfill.js module to prevent the `TypeError` exception when the getter on the proxy is related to a non-configurable read-only property of the original Proxy target (fixed by using an empty object which has the original target as its prototype as the "root" target of the Proxy instance created by the polyfill)
- a fix in the base browser-polyfill.js module to force devtools.panels.create to return a promise that resolves to a single callback argument (instead of an resolving to an array of arguments which contains an additional undocumented second parameter)
- fix applied on one of the existent tests (related to the `Proxy TypeError` fix)
- 2 additional test case (which covers the `Proxy TypeError` fix and the new `maxResolvedArgs` property in the `devtools.panels.create` metadata).