### PR TITLE
Fix: Support pageAction show/hide wrapping

### DIFF
--- a/api-metadata.json
+++ b/api-metadata.json
@@ -300,16 +300,16 @@
       "maxArgs": 1
     },
     "hide": {
-      "minArgs": 0,
-      "maxArgs": 0
+      "minArgs": 1,
+      "maxArgs": 1
     },
     "setIcon": {
       "minArgs": 1,
       "maxArgs": 1
     },
     "show": {
-      "minArgs": 0,
-      "maxArgs": 0
+      "minArgs": 1,
+      "maxArgs": 1
     }
   },
   "runtime": {

--- a/api-metadata.json
+++ b/api-metadata.json
@@ -295,21 +295,37 @@
       "minArgs": 1,
       "maxArgs": 1
     },
+    "setPopup": {
+      "minArgs": 1,
+      "maxArgs": 1,
+      "fallbackToNoCallback": true
+    },
     "getTitle": {
       "minArgs": 1,
       "maxArgs": 1
     },
+    "setTitle": {
+      "minArgs": 1,
+      "maxArgs": 1,
+      "fallbackToNoCallback": true
+    },
     "hide": {
       "minArgs": 1,
-      "maxArgs": 1
+      "maxArgs": 1,
+      "fallbackToNoCallback": true
     },
     "setIcon": {
       "minArgs": 1,
       "maxArgs": 1
     },
-    "show": {
+    "getIcon": {
       "minArgs": 1,
       "maxArgs": 1
+    },
+    "show": {
+      "minArgs": 1,
+      "maxArgs": 1,
+      "fallbackToNoCallback": true
     }
   },
   "runtime": {

--- a/test/fixtures/runtime-messaging-extension/background.js
+++ b/test/fixtures/runtime-messaging-extension/background.js
@@ -5,6 +5,12 @@ console.log(name, "background page loaded");
 browser.runtime.onMessage.addListener((msg, sender) => {
   console.log(name, "background received msg", {msg, sender});
 
+  try {
+    browser.pageAction.show(sender.tab.id);
+  } catch (err) {
+    return Promise.resolve(`Unexpected error on pageAction.show: ${err}`);
+  }
+
   return Promise.resolve("background page reply");
 });
 

--- a/test/fixtures/runtime-messaging-extension/manifest.json
+++ b/test/fixtures/runtime-messaging-extension/manifest.json
@@ -20,5 +20,8 @@
       "browser-polyfill.js",
       "background.js"
     ]
+  },
+  "page_action": {
+    "default_title": "a page action"
   }
 }


### PR DESCRIPTION
This PR contains the changes to the api-metadata.json from #9 and it also applies the changes needed into the polyfill wrappers to be able to customize the wrapper behavior for the API methods that returns a Promise on Firefox but do not accept a callback on Chrome (which is the case for pageAction.show and hide).