### PR TITLE
fix: Prevent 'Previous API instantiation failed' errors on runtime.sendMessage API calls

### DIFF
--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -348,10 +348,10 @@ if (typeof browser === "undefined") {
       },
     };
 
-    // Create an object that has the real target as its prototype
+    // Create a new empty object and copy the properties of the original chrome object
     // to prevent a Proxy violation exception for the devtools API getter
     // (which is a read-only non-configurable property on the original target).
-    const targetObject = Object.create(chrome);
+    const targetObject = Object.assign({}, chrome);
 
     return wrapObject(targetObject, staticWrappers, apiMetadata);
   };

--- a/test/test-proxied-properties.js
+++ b/test/test-proxied-properties.js
@@ -8,8 +8,10 @@ const {setupTestDOMWindow} = require("./setup");
 describe("browser-polyfill", () => {
   describe("proxies non-configurable read-only properties", () => {
     it("creates a proxy that doesn't raise a Proxy violation exception", () => {
-      const fakeChrome = {};
+      const fakeChrome = {"devtools": {}};
 
+      // Override the property to make it non-configurable (needed to be sure that
+      // the polyfill is correctly workarounding the Proxy TypeError).
       Object.defineProperty(fakeChrome, "devtools", {
         enumarable: true,
         configurable: false,
@@ -22,8 +24,6 @@ describe("browser-polyfill", () => {
       });
 
       return setupTestDOMWindow(fakeChrome).then(window => {
-        window.browser.devtools; // eslint-disable-line
-
         ok(window.browser.devtools.inspectedWindow,
            "The non-configurable read-only property can be accessed");
 


### PR DESCRIPTION
This PR contains changes which aims to fix #58 using a strategy that it is also able to fix the `Proxy TypeError` issues related to the devtools API namespace (#57).