### PR TITLE
Always use LF for dist files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -99,6 +99,8 @@ module.exports = function(grunt) {
     },
   });
 
+  grunt.util.linefeed = "\n";
+
   grunt.loadNpmTasks("gruntify-eslint");
   grunt.loadNpmTasks("grunt-replace");
   grunt.loadNpmTasks("grunt-coveralls");


### PR DESCRIPTION
This avoids got inconsistent line breaks and hash for `browser-polyfill.min.js` when build on Windows.

ref: https://github.com/gruntjs/grunt-contrib-concat/issues/20#issuecomment-15540197