### PR TITLE
Fix browser.runtime.getPackageDirectoryEntry

### DIFF
--- a/api-metadata.json
+++ b/api-metadata.json
@@ -319,6 +319,10 @@
       "minArgs": 0,
       "maxArgs": 0
     },
+    "getPackageDirectoryEntry": {
+      "minArgs": 0,
+      "maxArgs": 0
+    },
     "openOptionsPage": {
       "minArgs": 0,
       "maxArgs": 0


### PR DESCRIPTION
Fixes the following issue:

## Issue

Using

```js
const promise = browser.runtime.getPackageDirectoryEntry()
```

causes the following error:

```
Uncaught (in promise) Error: Invocation of form runtime.getPackageDirectoryEntry() doesn't match definition runtime.getPackageDirectoryEntry(function callback)
```

## Docs

* [mozilla](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/getPackageDirectoryEntry)
* [chrome](https://developer.chrome.com/apps/runtime)