### PR TITLE
fix: Pass --no-sandbox chrome CLI option when running the integration tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
 - echo "RUN integration tests on chrome" &&
-  ./test/run-chrome-smoketests.sh
+  TRAVIS_CI=true ./test/run-chrome-smoketests.sh
 
 after_script: npm run publish-coverage
 

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -1,6 +1,7 @@
 const finalhandler = require("finalhandler");
 const http = require("http");
 const serveStatic = require("serve-static");
+const puppeteer = require("puppeteer");
 
 exports.createHTTPServer = async (path) => {
   var serve = serveStatic(path);
@@ -17,5 +18,27 @@ exports.createHTTPServer = async (path) => {
         resolve(server);
       }
     });
+  });
+};
+
+exports.launchPuppeteer = async (puppeteerArgs) => {
+  if (!puppeteerArgs || !Array.isArray(puppeteerArgs)) {
+    throw new Error(`Invalid puppeteer arguments: ${JSON.stringify(puppeteerArgs)}`);
+  }
+
+  const args = [].concat(puppeteerArgs);
+
+  // Pass the --no-sandbox chrome CLI option when running the integration tests
+  // on Travis.
+  if (process.env.TRAVIS_CI) {
+    args.push("--no-sandbox");
+  }
+
+  return puppeteer.launch({
+    // Chrome Extensions are not currently supported in headless mode.
+    headless: false,
+
+    // Custom chrome arguments.
+    args,
   });
 };

--- a/test/integration/test-runtime-messaging-on-chrome.js
+++ b/test/integration/test-runtime-messaging-on-chrome.js
@@ -4,9 +4,8 @@ const path = require("path");
 
 const waitUntil = require("async-wait-until");
 const {deepEqual} = require("chai").assert;
-const puppeteer = require("puppeteer");
 
-const {createHTTPServer} = require("./setup");
+const {createHTTPServer, launchPuppeteer} = require("./setup");
 
 const fixtureExtensionDirName = "runtime-messaging-extension";
 
@@ -20,15 +19,9 @@ describe("browser.runtime.onMessage/sendMessage", function() {
 
     const url = `http://localhost:${server.address().port}`;
 
-    const browser = await puppeteer.launch({
-      // Chrome Extensions are not currently supported in headless mode.
-      headless: false,
-
-      // Custom chrome arguments.
-      args: [
-        `--load-extension=${process.env.TEST_EXTENSIONS_PATH}/${fixtureExtensionDirName}`,
-      ],
-    });
+    const browser = await launchPuppeteer([
+      `--load-extension=${process.env.TEST_EXTENSIONS_PATH}/${fixtureExtensionDirName}`,
+    ]);
 
     const page = await browser.newPage();
 


### PR DESCRIPTION
The integration tests are currently failing on Travis because it seems to be unable to run chrome without passing the --no-sandbox chrome CLI option:

- https://travis-ci.org/mozilla/webextension-polyfill/builds/326860218#L1864

This PR applies the changes needed to pass the --no-sandbox option to puppeteer if the integration tests are running in a Travis CI job.