### PR TITLE
feat: Added support for the sendResponse callback in the runtime.onMessage listeners

### DIFF
--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -361,18 +361,40 @@ if (typeof browser === "undefined") {
        *        yield a response. False otherwise.
        */
       return function onMessage(message, sender, sendResponse) {
-        let result = listener(message, sender);
+        let didCallSendResponse = false;
 
-        if (isThenable(result)) {
+        let wrappedSendResponse;
+        let sendResponsePromise = new Promise(resolve => {
+          wrappedSendResponse = function(response) {
+            didCallSendResponse = true;
+            resolve(response);
+          };
+        });
+
+        let result = listener(message, sender, wrappedSendResponse);
+
+        const isResultThenable = result !== true && isThenable(result);
+
+        // If the listener didn't returned true or a Promise, or called
+        // wrappedSendResponse synchronously, we can exit earlier
+        // because there will be no response sent from this listener.
+        if (result !== true && !isResultThenable && !didCallSendResponse) {
+          return false;
+        }
+
+        // If the listener returned a Promise, send the resolved value as a
+        // result, otherwise wait the promise related to the wrappedSendResponse
+        // callback to resolve and send it as a response.
+        if (isResultThenable) {
           result.then(sendResponse, error => {
             console.error(error);
-            sendResponse(error);
           });
-
-          return true;
-        } else if (result !== undefined) {
-          sendResponse(result);
+        } else {
+          sendResponsePromise.then(sendResponse);
         }
+
+        // Let Chrome know that the listener is replying.
+        return true;
       };
     });
 

--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -388,9 +388,20 @@ if (typeof browser === "undefined") {
         if (isResultThenable) {
           result.then(sendResponse, error => {
             console.error(error);
+            // TODO: the error object is not serializable and so for now we just send
+            // `undefined`. Nevertheless, as being discussed in #97, this is not yet
+            // providing the expected behavior (the promise received from the sender should
+            // be rejected when the promise returned by the listener is being rejected).
+            sendResponse(undefined);
           });
         } else {
-          sendResponsePromise.then(sendResponse);
+          sendResponsePromise.then(sendResponse, error => {
+            console.error(error);
+            // TODO: same as above, we are currently sending `undefined` in this scenario
+            // because the error oject is not serializable, but it is not yet the behavior
+            // that this scenario should present.
+            sendResponse(undefined);
+          });
         }
 
         // Let Chrome know that the listener is replying.

--- a/test/fixtures/runtime-messaging-extension/background.js
+++ b/test/fixtures/runtime-messaging-extension/background.js
@@ -2,16 +2,49 @@ const {name} = browser.runtime.getManifest();
 
 console.log(name, "background page loaded");
 
-browser.runtime.onMessage.addListener((msg, sender) => {
+browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   console.log(name, "background received msg", {msg, sender});
 
-  try {
-    browser.pageAction.show(sender.tab.id);
-  } catch (err) {
-    return Promise.resolve(`Unexpected error on pageAction.show: ${err}`);
-  }
+  switch (msg) {
+    case "test - sendMessage with returned Promise reply":
+      try {
+        browser.pageAction.show(sender.tab.id);
+      } catch (err) {
+        return Promise.resolve(`Unexpected error on pageAction.show: ${err}`);
+      }
 
-  return Promise.resolve("background page reply");
+      return Promise.resolve("bg page reply 1");
+
+    case "test - sendMessage with returned value reply":
+      // This is supposed to be ignored and the sender should receive
+      // a reply from the second listener.
+      return "Unexpected behavior: a plain return value should not be sent as a result";
+
+    case "test - sendMessage with synchronous sendResponse":
+      sendResponse("bg page reply 3");
+      return "value returned after calling sendResponse synchrously";
+
+    case "test - sendMessage with asynchronous sendResponse":
+      setTimeout(() => sendResponse("bg page reply 4"), 50);
+      return true;
+
+    case "test - second listener if the first does not reply":
+      // This is supposed to be ignored and the sender should receive
+      // a reply from the second listener.
+      return false;
+
+    default:
+      return Promise.resolve(
+        `Unxpected message received by the background page: ${JSON.stringify(msg)}\n`);
+  }
+});
+
+browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  setTimeout(() => {
+    sendResponse("second listener reply");
+  }, 100);
+
+  return true;
 });
 
 console.log(name, "background page ready to receive a content script message...");

--- a/test/fixtures/runtime-messaging-extension/content.js
+++ b/test/fixtures/runtime-messaging-extension/content.js
@@ -1,9 +1,27 @@
 const {name} = browser.runtime.getManifest();
 
+async function runTest() {
+  let reply;
+  reply = await browser.runtime.sendMessage("test - sendMessage with returned Promise reply");
+  console.log(name, "test - returned resolved Promise - received", reply);
+
+  reply = await browser.runtime.sendMessage("test - sendMessage with returned value reply");
+  console.log(name, "test - returned value - received", reply);
+
+  reply = await browser.runtime.sendMessage("test - sendMessage with synchronous sendResponse");
+  console.log(name, "test - synchronous sendResponse - received", reply);
+
+  reply = await browser.runtime.sendMessage("test - sendMessage with asynchronous sendResponse");
+  console.log(name, "test - asynchronous sendResponse - received", reply);
+
+  reply = await browser.runtime.sendMessage("test - second listener if the first does not reply");
+  console.log(name, "test - second listener sendResponse - received", reply);
+
+  console.log(name, "content script messages sent");
+}
+
 console.log(name, "content script loaded");
 
-browser.runtime.sendMessage("content script message").then(reply => {
-  console.log(name, "content script received reply", {reply});
+runTest().catch((err) => {
+  console.error("content script error", err);
 });
-
-console.log(name, "content script message sent");

--- a/test/integration/test-runtime-messaging-on-chrome.js
+++ b/test/integration/test-runtime-messaging-on-chrome.js
@@ -40,8 +40,12 @@ describe("browser.runtime.onMessage/sendMessage", function() {
 
     const expectedConsoleMessages = [
       [extensionName, "content script loaded"],
-      [extensionName, "content script message sent"],
-      [extensionName, "content script received reply", {"reply": "background page reply"}],
+      [extensionName, "test - returned resolved Promise - received", "bg page reply 1"],
+      [extensionName, "test - returned value - received", "second listener reply"],
+      [extensionName, "test - synchronous sendResponse - received", "bg page reply 3"],
+      [extensionName, "test - asynchronous sendResponse - received", "bg page reply 4"],
+      [extensionName, "test - second listener sendResponse - received", "second listener reply"],
+      [extensionName, "content script messages sent"],
     ];
 
     const lastExpectedMessage = expectedConsoleMessages.slice(-1).pop();

--- a/test/test-runtime-onMessage.js
+++ b/test/test-runtime-onMessage.js
@@ -176,7 +176,7 @@ describe("browser-polyfill", () => {
       return setupTestDOMWindow(fakeChrome).then(window => {
         const listenerReturnsFalse = sinon.spy((msg, sender, sendResponse) => {
           waitPromises.push(Promise.resolve().then(() => {
-            sendResponse("Ignored sendReponse callback on returned Promise");
+            sendResponse("Ignored sendReponse callback on returned false");
           }));
 
           return false;
@@ -184,7 +184,7 @@ describe("browser-polyfill", () => {
 
         const listenerReturnsValue = sinon.spy((msg, sender, sendResponse) => {
           waitPromises.push(Promise.resolve().then(() => {
-            sendResponse("Ignored sendReponse callback on returned Promise");
+            sendResponse("Ignored sendReponse callback on non boolean/thenable return values");
           }));
 
           // Any return value that is not a promise should not be sent as a response,


### PR DESCRIPTION
This pull requests contains a reworked version of Rob's pull request #22 which aimed to fix #16 by implementing a wrapper for the runtime.onMessage API event which would behave similarly to how it works natively on Firefox (and described in the related API docs on MDN).

Starting from the original #22 pull request, I applied the following changes:

- fixes on the runtime.onMessage listener wrapper to implement the following two scenario as in Firefox:
  - when the listener calls the sendResponse but also returns a promise, the sendResponse calls should be ignored (basically the returned promise has an higher precedence and it will override any sendResponse calls, both synchronously called in the listener or asynchronously called after the listener returns)
  - the listener return value is used to send a response only if it is a promise, any other plain return value should to be just ignored (and it is going to be considered as "this listener is not going to call sendResponse asynchronously")
  - if the listener return value is `true`, we should let Chrome know that the listener is going to call sendResponse asynchronously (by ensuring to `return true` also from the "listener wrapper" generated by this polyfill)

- simplify and fix the new unit tests (so that they actually cover the above expected behaviors)

- added a small smoke test to verify that the the polyfill wrappers are working as expected when running on a real Chrome test extension, and that they behave as expected in the above scenarios 

Follows some additional context about the initial decision about #16 and the why I think it is time to re-evaluate that decision:

At the time we closed #22 and marked #16 as wontfix because the sendResponse callback was expected to be deprecated in the w3c draft once it would have also been updated to include the Promise-based API (https://github.com/mozilla/webextension-polyfill/issues/16#issuecomment-296693219).

Almost 1 year later, it seems reasonable to me to look again at the updated w3c draft and verify if it has been updated as expected or if fixing #16 is something that would be worth to re-evaluate.

Unfortunately it seems that, while the w3c draft has been updated to the Promise-based API (more or less defined as implemented in Firefox natively, and by this polyfill where it is not supported natively, with some exceptions e.g. the pageAction.show/hide in the w3c draft do not seem to return any Promise, at least not yet), but the sendResponse callback seems to be still part of the proposal and so the behavior implemented by this polyfill is still going to be confusing for a lot of the developers, especially because the API docs on MDN (as well as the API docs from Chrome) still mention the usage of the sendResponse callback.

Also, by looking into the w3c draft, it seems that sendResponse callback has been even updated to mention that it is "an asynchronous function that returns a Promise" (from: https://browserext.github.io/browserext/#dom-browserextbrowsertabs-sendmessage), which is not actually true even in Firefox where the Promise-based APIs are natively supported.

If at some point the w3c draft will actually be updated to remove the sendResponse callback, we can plan the updates to apply on the polyfill accordingly (e.g. as a first step we may log a warning message when the sendResponse callback is called and points the developer to an updated doc page, and then as a second step we may raise an error every time the sendResponse callback is called and then remove sendResponse completely in a third step, or just removing the sendResponse completely as the second step).