### PR TITLE
chore(test): Fixed module bundlers tests on webpack 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
 - npm run test-coverage
 - echo "RE-RUN tests on the minified file" && npm run test-minified
 - echo "RE-RUN tests on the webpack and browserify bundled files" &&
-  npm install -g browserify webpack &&
+  npm install -g browserify webpack webpack-cli &&
   ./test/run-module-bundlers-smoketests.sh
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start

--- a/test/run-module-bundlers-smoketests.sh
+++ b/test/run-module-bundlers-smoketests.sh
@@ -1,7 +1,7 @@
 echo "\nTest webextension-polyfill bundled with webpack"
 echo "==============================================="
 
-webpack test/fixtures/bundle-entrypoint.js /tmp/webpack-bundle.js
+webpack --mode production --entry ./test/fixtures/bundle-entrypoint.js --output /tmp/webpack-bundle.js
 TEST_BUNDLED_POLYFILL=/tmp/webpack-bundle.js npm run test
 
 echo "\nTest webextension-polyfill bundled with browserify"


### PR DESCRIPTION
This pull request applies some minor fixes to the module bundlers tests with webpack 4 (which were recently failing on the CI jobs because of the some minor incompatibilities between webpack 3 and webpack 4 cli tool).