### PR TITLE
feat: Tool to automatically collect API information from Chrome

### DIFF
--- a/tools/metadata-generator/README.md
+++ b/tools/metadata-generator/README.md
@@ -1,0 +1,64 @@
+This tool collects the API namespaces from Chrome.
+
+### Usage
+
+1. Start `./collector.js`
+2. Start Chrome and load the two extensions (there are two extensions because
+   it is not possible to have one extension with all APIs).
+3. Start Chrome again, with `--enable-features=NativeCrxBindings` and load one
+   of the two extensions.
+4. To support older versions of Chrome (which may have different API expectations),
+   repeat step 3 for each version of Chrome.
+
+When you are done, the collected metadata is available at http://127.0.0.1:55781/
+
+To only see the namespaces that already exist in api-manifest.json, visit
+http://127.0.0.1:55781/subset
+
+Then use jsondiff, e.g. jsondiff.com to compare the old and new metadata.
+
+
+### Example
+For example, to collect the metadata from multiple sources:
+
+```sh
+node ./collector.js
+
+# Now in a different terminal:
+chromium --no-first-run --user-data-dir=/tmp/whatever --load-extension=extension-apis,extension-apis/browseraction data:,extension-apis data:,browseraction
+chromium --no-first-run --user-data-dir=/tmp/whatever --load-extension=extension-apis --enable-features=NativeCrxBindings data:,extension-apis
+
+# If repeating the last line for old Chrome versions, remove the profile dir
+# first using:   rm -r /tmp/whatever
+
+# See JSON output in stdout
+curl http://127.0.0.1:55781/subset
+
+# When you are done, go back to the terminal that runs collector.js and ^C
+```
+
+Explanation of above commands:
+
+- `--load-extension=comma-separated-list-of-directories to load extension(s).
+- `data:,extension-apis` is a data-URL.
+  The part after "data:," matches with the `short_name` value in manifest.json.
+  After collecting the API information, the extension will look for a tab with
+  such a URL and close it. If it is the last tab, Chrome will automatically
+  shut down.
+- `--enable-features=NativeCrxBindings` forces Chrome to use C++ extension
+  bindings. These have more consistent error messages, except for some APIs
+  such as the storage API ( https://crbug.com/848904 ). If this bug is fixed,
+  then it suffices to run Chrome only once (always with this flag enabled).
+
+### Analysis
+After collecting the data, you can use diff tools of your choice to check for
+differences. Examples:
+
+```sh
+# Assuming that the server is still up:
+colordiff -u ../../api-metadata.json <(curl http://127.0.0.1:55781/subset)
+
+# Or if you saved the result, e.g. as out.json
+curl http://127.0.0.1:55781/subset > out.json
+colordiff -u ../../api-metadata.json out.json
+```

--- a/tools/metadata-generator/collector.js
+++ b/tools/metadata-generator/collector.js
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/* eslint-env node */
+
+var PORT = 55781; // A random number, chosen with (Math.random() * 0xFFFF | 0)
+// The above number must match the PORT in explorer.js
+
+var collectedSignatures = {};
+
+// The set of APIs with a mismatching callback (i.e one client says optional,
+// the other says required).
+var mismatchedCallbacks = new Set();
+
+function mergeSignatures(sigs) {
+  let newcount = 0;
+  for (let [path, newSig] of Object.entries(sigs)) {
+    let oldSig = collectedSignatures[path];
+    if (newSig.TODO) {
+      if (!oldSig || oldSig.TODO) {
+        collectedSignatures[path] = newSig;
+      }
+      // Otherwise the signature is known and we ignore the TODO.
+      continue;
+    }
+    if (!oldSig || oldSig.TODO) {
+      collectedSignatures[path] = newSig;
+      ++newcount;
+    } else {
+      if (oldSig.minArgs !== newSig.minArgs) {
+        console.log(`${path} mismatch in minArgs, taking the minimum (${oldSig.minArgs} vs ${newSig.minArgs})`);
+        oldSig.minArgs = Math.min(oldSig.minArgs, newSig.minArgs);
+      }
+      if (oldSig.maxArgs !== newSig.maxArgs) {
+        console.log(`${path} mismatch in maxArgs, taking the maximum (${oldSig.maxArgs} vs ${newSig.maxArgs})`);
+        oldSig.maxArgs = Math.max(oldSig.maxArgs, newSig.maxArgs);
+      }
+      if (oldSig.fallbackToNoCallback !== newSig.fallbackToNoCallback) {
+        console.log(`${path} mismatch in fallbackToNoCallback, assuming true`);
+        oldSig.fallbackToNoCallback = true;
+        mismatchedCallbacks.add(path);
+      }
+    }
+  }
+  console.log(`Imported ${Object.keys(sigs).length} signatures (${newcount} new).`);
+  let todocount = Object.values(collectedSignatures).filter(sig => sig.TODO).length;
+  if (todocount) {
+    console.log(`${todocount} signatures are invalid. Fix this by running Chrome with and without --enable-features=NativeCrxBindings.`);
+  } else {
+    console.log(`All collected signatures are valid.`);
+  }
+  console.log(`The API metadata collected so far is available as JSON via GET:
+   http://127.0.0.1:${PORT}/         has all data.
+   http://127.0.0.1:${PORT}/subset   only returns the common namespaces.
+  `);
+}
+
+/**
+ * Sets obj.path = value, expanding path if there are any dots inside.
+ *
+ * @param {object} obj
+ * @param {string} path
+ * @param {object} value
+ */
+function setPathValue(obj, path, value) {
+  let parts = path.split(".");
+  for (let part of parts.slice(0, -1)) {
+    if (!obj[part]) {
+      obj[part] = {};
+    }
+    obj = obj[part];
+  }
+  obj[parts.pop()] = value;
+}
+
+function generateObjectWithSortedKeys(obj) {
+  let res = {};
+  for (let key of Object.keys(obj).sort()) {
+    res[key] = obj[key];
+  }
+  return res;
+}
+
+function serializeSignatures(signatures, subset) {
+  // Sort inputs to have a stable output format.
+  signatures = generateObjectWithSortedKeys(signatures);
+
+  let result = {};
+  for (let [path, signature] of Object.entries(signatures)) {
+    if (signature.TODO) {
+      console.log(`${path} has no known signature. Reason: ${signature.TODO}`);
+      continue;
+    }
+    if (signature.fallbackToNoCallback && !mismatchedCallbacks.has(path)) {
+      continue;
+    }
+    setPathValue(result, path, signature);
+  }
+
+  if (subset) {
+    let metadatalocation = require("path").join(__dirname, "..", "..", "api-metadata.json");
+    let metadata = require("fs").readFileSync(metadatalocation, {encoding: "utf-8"});
+    let parsed = JSON.parse(metadata);
+    for (let namespaceroot of Object.keys(result)) {
+      if (!parsed.hasOwnProperty(namespaceroot)) {
+        console.log(`${namespaceroot} is not in ${metadatalocation} and therefore excluded.`);
+        delete result[namespaceroot];
+      }
+    }
+  }
+
+  return JSON.stringify(result, null, 2);
+}
+
+require("http").createServer(function(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end(serializeSignatures(collectedSignatures, req.url === "/subset"));
+    return;
+  }
+  let buffers = [];
+  req.on("data", function(chunk) {
+    buffers.push(chunk);
+  });
+  req.on("end", function() {
+    res.end();
+
+    let data = Buffer.concat(buffers).toString("utf8");
+    // Note: We trust the client to provide valid JSON.
+    try {
+      mergeSignatures(JSON.parse(data));
+    } catch (e) {
+      console.log(`Failed to import signatures: ${e}`);
+      return;
+    }
+  });
+}).listen(PORT, "127.0.0.1", function() {
+  console.log(`
+Started server at http://127.0.0.1:${PORT}
+Now start Chrome and load the extensions from:
+extension-apis/
+extension-apis/browseraction/
+`);
+  // (^ In case you wonder, the extensions are nested so that they can share
+  //    a script, located at the deepest directory level.)
+});

--- a/tools/metadata-generator/extension-apis/browseraction/explorer.js
+++ b/tools/metadata-generator/extension-apis/browseraction/explorer.js
@@ -1,0 +1,156 @@
+"use strict";
+/**
+ * This file walks the extension API namespace and
+ * infers the expected API format from the error messages.
+ * See schemaErrorToSignature for the signature mapping logic.
+ * Call generateApiMetadata() to see the generated signatures.
+ *
+ * collectAndSend() will be called and kick off the signature collection.
+ */
+
+// A list of arguments that is never valid.
+const INVALID_ARGUMENT_LIST = new Array(9).fill(Symbol.for("INVALID_ARGUMENT_SYMBOL"));
+
+function ignorePath(fullpath, rootpath, key) {
+  if (rootpath === "") {
+    return key === "app" ||
+      key === "csi" ||
+      key === "loadTimes" ||
+      key === "Event";
+  }
+  return (
+    // Events are handled separately.
+    key.startsWith("on") ||
+    // Constructors never take callbacks.
+    /^[A-Z]/.test(key) ||
+    // The only API that takes a callback and also returns a non-void value.
+    fullpath === "contextMenus.create" ||
+    // ContentSettings and BrowserSettings objects do not provide the method
+    // signatures when an error is thrown.
+    /^contentSettings\.[^.]+$/.test(rootpath) ||
+    /^privacy\.[^.]+\.[^.]+$/.test(rootpath) ||
+    rootpath === "proxy.settings"
+  );
+}
+
+function exploreObject(obj, rootpath = "", collectedErrors = {}) {
+  if (typeof obj !== "object" || obj === null) {
+    return;
+  }
+  for (let key of Object.keys(obj)) {
+    let path = rootpath ? `${rootpath}.${key}` : key;
+    if (ignorePath(path, rootpath, key)) {
+      continue;
+    }
+    let value;
+    try {
+      value = obj[key];
+    } catch (e) {
+      console.warn(`Failed to read property: ${path}`);
+      continue;
+    }
+    if (typeof value === "object") {
+      exploreObject(value, path, collectedErrors);
+      continue;
+    }
+    if (typeof value !== "function") {
+      continue;
+    }
+
+    let err;
+    try {
+      value.apply(obj, INVALID_ARGUMENT_LIST);
+    } catch (e) {
+      err = e;
+    }
+    if (!err) {
+      console.warn(`${path}(...) did not throw`);
+      continue;
+    }
+    collectedErrors[path] = err.message;
+  }
+  return collectedErrors;
+}
+
+function schemaErrorToSignature(errorMessage) {
+  // JS-based schema error.
+  // https://chromium.googlesource.com/chromium/src/+/1526d82653413c5c812f1b6d869e7b29389f5398/extensions/renderer/resources/schema_utils.js#115
+  // E.g. "Invocation of form alarms.clear(symbol, symbol, symbol, symbol, symbol, symbol, symbol, symbol, symbol, symbol) doesn't match definition alarms.clear(optional string name, optional function callback)"
+  let tmp = /doesn't match definition [^(]+\(([^)]*)\)/.exec(errorMessage);
+  if (!tmp) {
+    // C++ schema error (--enable-features=NativeCrxBindings)
+    // https://chromium.googlesource.com/chromium/src/+/1526d82653413c5c812f1b6d869e7b29389f5398/extensions/renderer/bindings/api_invocation_errors.cc#121
+    // E.g. "Error in invocation of alarms.clear(optional string name, optional function callback): No matching signature."
+    tmp = /Error in invocation of [^(]+\(([^)]*)\)/.exec(errorMessage);
+  }
+  if (!tmp) {
+    return {
+      TODO: `No signature found in: ${errorMessage}`,
+    };
+  }
+  let params = tmp[1].split(", ");
+
+  let countRequiredParams = args => args.filter(sig => !sig.startsWith("optional")).length;
+  let hasCallback = params.length > 0 && /( |^)function /.test(params[params.length - 1]);
+  if (!hasCallback) {
+    // Does not take a callback as last parameter.
+    return {
+      minArgs: countRequiredParams(params),
+      maxArgs: params.length,
+      // Placeholder. We need to manually check if the API should be kept or be removed.
+      fallbackToNoCallback: true,
+    };
+  }
+  // We could check if the callback is optional by using lastparam.startsWith("optional"),
+  // but since we always pass a callback in the polyfill, there is no need to distinguish
+  // between the two (and we can always ignore the last parameter).
+  // (At least, until there exist some API that takes two callback functions.
+  //  So far, there is not any such function.)
+  return {
+    minArgs: countRequiredParams(params.slice(0, -1)),
+    maxArgs: params.length - 1,
+  };
+}
+
+/**
+ * @returns {object}
+ *          A dictionary that maps API paths to {minArgs,maxArgs}
+ *          (and optionally "fallbackToNoCallback" if the API does not take callbacks).
+ */
+function generateApiMetadata() {
+  let collectedErrors = exploreObject(chrome);
+
+  let signatures = {};
+  for (let [path, errorMessage] of Object.entries(collectedErrors)) {
+    let signature = schemaErrorToSignature(errorMessage);
+    if (signature) {
+      if (signature.TODO) {
+        // Manual action = figuring out the signature, e.g. by reading the documentation,
+        // or by running a different version of Chrome, and/or with --enable-features=NativeCrxBindings
+        console.warn(`No signature found for ${path}; needs manual fixup or a different source.`);
+      }
+      signatures[path] = signature;
+    }
+  }
+
+  return signatures;
+}
+
+function collectAndSend() {
+  let signatures = generateApiMetadata();
+  let x = new XMLHttpRequest();
+  x.onloadend = function() {
+    console.log(`Sent ${Object.keys(signatures).length} signatures to ${x.responseURL} (${x.status})`);
+
+    chrome.tabs.query({
+      url: "data:," + chrome.runtime.getManifest().short_name,
+    }, function(tabs) {
+      // If the tab exists and if it is the last one, then the browser will shut down.
+      chrome.tabs.remove(tabs[0].id);
+    });
+  };
+  x.open("POST", "http://127.0.0.1:55781/"); // This PORT must match collector.js
+  x.send(JSON.stringify(signatures));
+}
+
+collectAndSend();

--- a/tools/metadata-generator/extension-apis/browseraction/manifest.json
+++ b/tools/metadata-generator/extension-apis/browseraction/manifest.json
@@ -1,0 +1,17 @@
+{
+    "name": "Extension with browserAction API",
+    "short_name": "browseraction",
+    "version": "1",
+    "manifest_version": 2,
+
+    "background": {
+        "scripts": [
+            "explorer.js"
+        ]
+    },
+    "browser_action": {
+    },
+    "permissions": [
+        "tabs"
+    ]
+}

--- a/tools/metadata-generator/extension-apis/manifest.json
+++ b/tools/metadata-generator/extension-apis/manifest.json
@@ -1,0 +1,64 @@
+{
+    "name": "Extension with all APIs except browserAction",
+    "short_name": "extension-apis",
+    "description": "All stable APIs except for browser_action and devtools",
+    "version": "1",
+    "manifest_version": 2,
+
+    "background": {
+        "scripts": [
+            "browseraction/explorer.js"
+        ]
+    },
+    "commands": {
+    },
+    "omnibox": {
+        "keyword": "testkeyword"
+    },
+    "optional_permissions": [
+    ],
+    "page_action": {
+    },
+    "permissions": [
+        "alarms",
+        "bookmarks",
+        "browsingData",
+        "contentSettings",
+        "contextMenus",
+        "cookies",
+        "debugger",
+        "declarativeContent",
+        "desktopCapture",
+        "downloads",
+        "downloads.open",
+        "downloads.shelf",
+        "fontSettings",
+        "gcm",
+        "history",
+        "identity",
+        "idle",
+        "management",
+        "nativeMessaging",
+        "notifications",
+        "pageCapture",
+        "power",
+        "printerProvider",
+        "privacy",
+        "proxy",
+        "sessions",
+        "storage",
+        "system.cpu",
+        "system.memory",
+        "system.storage",
+        "system.display",
+        "tabCapture",
+        "tabs",
+        "topSites",
+        "tts",
+        "ttsEngine",
+        "webNavigation",
+        "webRequest",
+        "windows",
+        "<all_urls>"
+    ]
+}


### PR DESCRIPTION
This tool automatically generates metadata from Chrome's runtime, by walking the API namespace, calling the methods with invalid parameters and catching the error. The error message includes a useful method signature.

This PR contains two test extensions, because the `page_action` and `browser_action` manifest keys are mutually exclusive.  I have added a Node.js server to collect and merge the results from separate runs.

The permissions to unlock the APIs are based on:

- https://developer.chrome.com/extensions/api_index
- https://developer.chrome.com/extensions/permission_warnings#permissions_with_warnings

I double-checked with:

- https://chromium.googlesource.com/chromium/src/+/2f2f1153ea9f8e6c5f277ee5a7cbfc242bf6d3ce/extensions/common/api/_permission_features.json

Alternatives that I have considered and rejected:

- Parsing the schemas directly from the source code. Chromium's API definitions are scattered over JSON and IDL files (for schemas) and also some other files for permissions and availability (JSON). I didn't want to write a new parser for it. The source also contains Python scripts that parse everything, but re-using to get our desired information takes some efforts (and a multi-GB Chromium checkout).
- Scraping the schemas from Chrome's documentation: Rejected because the documentation is not consistently updated: https://bugs.chromium.org/p/chromium/issues/detail?id=513780#c23