### PR TITLE
fix: Update existing namespaces in api-metadata.json

### DIFF
--- a/api-metadata.json
+++ b/api-metadata.json
@@ -177,11 +177,11 @@
     }
   },
   "downloads": {
-    "download": {
+    "cancel": {
       "minArgs": 1,
       "maxArgs": 1
     },
-    "cancel": {
+    "download": {
       "minArgs": 1,
       "maxArgs": 1
     },
@@ -195,7 +195,8 @@
     },
     "open": {
       "minArgs": 1,
-      "maxArgs": 1
+      "maxArgs": 1,
+      "fallbackToNoCallback": true
     },
     "pause": {
       "minArgs": 1,
@@ -215,7 +216,8 @@
     },
     "show": {
       "minArgs": 1,
-      "maxArgs": 1
+      "maxArgs": 1,
+      "fallbackToNoCallback": true
     }
   },
   "extension": {

--- a/api-metadata.json
+++ b/api-metadata.json
@@ -64,6 +64,16 @@
     }
   },
   "browserAction": {
+    "disable": {
+      "minArgs": 0,
+      "maxArgs": 1,
+      "fallbackToNoCallback": true
+    },
+    "enable": {
+      "minArgs": 0,
+      "maxArgs": 1,
+      "fallbackToNoCallback": true
+    },
     "getBadgeBackgroundColor": {
       "minArgs": 1,
       "maxArgs": 1
@@ -80,9 +90,33 @@
       "minArgs": 1,
       "maxArgs": 1
     },
+    "openPopup": {
+      "minArgs": 0,
+      "maxArgs": 0
+    },
+    "setBadgeBackgroundColor": {
+      "minArgs": 1,
+      "maxArgs": 1,
+      "fallbackToNoCallback": true
+    },
+    "setBadgeText": {
+      "minArgs": 1,
+      "maxArgs": 1,
+      "fallbackToNoCallback": true
+    },
     "setIcon": {
       "minArgs": 1,
       "maxArgs": 1
+    },
+    "setPopup": {
+      "minArgs": 1,
+      "maxArgs": 1,
+      "fallbackToNoCallback": true
+    },
+    "setTitle": {
+      "minArgs": 1,
+      "maxArgs": 1,
+      "fallbackToNoCallback": true
     }
   },
   "commands": {

--- a/api-metadata.json
+++ b/api-metadata.json
@@ -235,10 +235,6 @@
       "minArgs": 1,
       "maxArgs": 1
     },
-    "getVisits": {
-      "minArgs": 1,
-      "maxArgs": 1
-    },
     "deleteAll": {
       "minArgs": 0,
       "maxArgs": 0
@@ -248,6 +244,10 @@
       "maxArgs": 1
     },
     "deleteUrl": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "getVisits": {
       "minArgs": 1,
       "maxArgs": 1
     },

--- a/api-metadata.json
+++ b/api-metadata.json
@@ -447,13 +447,13 @@
     }
   },
   "tabs": {
-    "create": {
-      "minArgs": 1,
-      "maxArgs": 1
-    },
     "captureVisibleTab": {
       "minArgs": 0,
       "maxArgs": 2
+    },
+    "create": {
+      "minArgs": 1,
+      "maxArgs": 1
     },
     "detectLanguage": {
       "minArgs": 0,
@@ -495,15 +495,15 @@
       "minArgs": 2,
       "maxArgs": 2
     },
+    "query": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
     "reload": {
       "minArgs": 0,
       "maxArgs": 2
     },
     "remove": {
-      "minArgs": 1,
-      "maxArgs": 1
-    },
-    "query": {
       "minArgs": 1,
       "maxArgs": 1
     },

--- a/api-metadata.json
+++ b/api-metadata.json
@@ -291,6 +291,10 @@
       "minArgs": 0,
       "maxArgs": 0
     },
+    "setEnabled": {
+      "minArgs": 2,
+      "maxArgs": 2
+    },
     "uninstallSelf": {
       "minArgs": 0,
       "maxArgs": 1

--- a/api-metadata.json
+++ b/api-metadata.json
@@ -327,19 +327,9 @@
       "minArgs": 1,
       "maxArgs": 1
     },
-    "setPopup": {
-      "minArgs": 1,
-      "maxArgs": 1,
-      "fallbackToNoCallback": true
-    },
     "getTitle": {
       "minArgs": 1,
       "maxArgs": 1
-    },
-    "setTitle": {
-      "minArgs": 1,
-      "maxArgs": 1,
-      "fallbackToNoCallback": true
     },
     "hide": {
       "minArgs": 1,
@@ -350,9 +340,15 @@
       "minArgs": 1,
       "maxArgs": 1
     },
-    "getIcon": {
+    "setPopup": {
       "minArgs": 1,
-      "maxArgs": 1
+      "maxArgs": 1,
+      "fallbackToNoCallback": true
+    },
+    "setTitle": {
+      "minArgs": 1,
+      "maxArgs": 1,
+      "fallbackToNoCallback": true
     },
     "show": {
       "minArgs": 1,

--- a/api-metadata.json
+++ b/api-metadata.json
@@ -459,6 +459,10 @@
       "minArgs": 0,
       "maxArgs": 1
     },
+    "discard": {
+      "minArgs": 0,
+      "maxArgs": 1
+    },
     "duplicate": {
       "minArgs": 1,
       "maxArgs": 1

--- a/api-metadata.json
+++ b/api-metadata.json
@@ -126,10 +126,6 @@
     }
   },
   "contextMenus": {
-    "update": {
-      "minArgs": 2,
-      "maxArgs": 2
-    },
     "remove": {
       "minArgs": 1,
       "maxArgs": 1
@@ -137,6 +133,10 @@
     "removeAll": {
       "minArgs": 0,
       "maxArgs": 0
+    },
+    "update": {
+      "minArgs": 2,
+      "maxArgs": 2
     }
   },
   "cookies": {

--- a/api-metadata.json
+++ b/api-metadata.json
@@ -22,10 +22,6 @@
       "minArgs": 1,
       "maxArgs": 1
     },
-    "export": {
-      "minArgs": 0,
-      "maxArgs": 0
-    },
     "get": {
       "minArgs": 1,
       "maxArgs": 1
@@ -38,15 +34,11 @@
       "minArgs": 1,
       "maxArgs": 1
     },
-    "getTree": {
-      "minArgs": 0,
-      "maxArgs": 0
-    },
     "getSubTree": {
       "minArgs": 1,
       "maxArgs": 1
     },
-    "import": {
+    "getTree": {
       "minArgs": 0,
       "maxArgs": 0
     },


### PR DESCRIPTION
I have auto-generated the schema signatures for Chrome 54 and Chrome 67, and manually merged the result, as follows:

- Ensure that the keys are alphabetically sorted.
- Remove keys that are not implemented by either browser.
- Add methods that are supported by both Firefox and Chrome.
- Add fallbackToNoCallback where needed.

This PR only modifies existing namespaces. Missing namespaces will be added by other PRs.

Fixes #26 
Fixes #93 

The diff between the output of #122 and the api-metadata after this is as follows (I added comments to explain the discrepancies):

```diff
164,178d163
  The tool from #122 does not generate the devtools namespace
<   "devtools": {
<     "inspectedWindow": {
<       "eval": {
<         "minArgs": 1,
<         "maxArgs": 2
<       }
<     },
<     "panels": {
<       "create": {
<         "minArgs": 3,
<         "maxArgs": 3,
<         "singleCallbackArg": true
<       }
<     }
<   },
179a165,168
  Firefox does not support acceptDanger.
>     "acceptDanger": {
>       "minArgs": 1,
>       "maxArgs": 1
>     },
196,200d184
  Chrome's downloads.open method does not take a callback.
  (and the tool omits all non-callback methods).
<     "open": {
<       "minArgs": 1,
<       "maxArgs": 1,
<       "fallbackToNoCallback": true
<     },
216,220d199
  Chrome's downloads.show method does not take a callback.
  (and the tool omits all non-callback methods).
<     },
<     "show": {
<       "minArgs": 1,
<       "maxArgs": 1,
<       "fallbackToNoCallback": true
230a210,221
  Firefox does not support extension messaging in the extension namespace.
  (only in the runtime namespace)
>     },
>     "sendMessage": {
>       "minArgs": 1,
>       "maxArgs": 3
>     },
>     "sendNativeMessage": {
>       "minArgs": 2,
>       "maxArgs": 2
>     },
>     "sendRequest": {
>       "minArgs": 1,
>       "maxArgs": 2
269a261,272
  Firefox's identity API does not support several of Chrome's.
  https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/identity#Functions
  https://developer.chrome.com/extensions/identity#toc
>     "getAccounts": {
>       "minArgs": 0,
>       "maxArgs": 0
>     },
>     "getAuthToken": {
>       "minArgs": 0,
>       "maxArgs": 1
>     },
>     "getProfileUserInfo": {
>       "minArgs": 0,
>       "maxArgs": 0
>     },
272a276,279
>     },
>     "removeCachedAuthToken": {
>       "minArgs": 1,
>       "maxArgs": 1
281a289,296
  Firefox's management API does not support all of Chrome's APIs
  https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/management#Functions
  https://developer.chrome.com/extensions/management#toc
>     "createAppShortcut": {
>       "minArgs": 1,
>       "maxArgs": 1
>     },
>     "generateAppForLink": {
>       "minArgs": 2,
>       "maxArgs": 2
>     },
289a305,312
>     "getPermissionWarningsById": {
>       "minArgs": 1,
>       "maxArgs": 1
>     },
>     "getPermissionWarningsByManifest": {
>       "minArgs": 1,
>       "maxArgs": 1
>     },
293a317,320
>     "launchApp": {
>       "minArgs": 1,
>       "maxArgs": 1
>     },
297a325,332
>     "setLaunchType": {
>       "minArgs": 2,
>       "maxArgs": 2
>     },
>     "uninstall": {
>       "minArgs": 1,
>       "maxArgs": 2
>     },
364c399
  Chrome does not support runtime.getBrowserInfo,
<     "getBrowserInfo": {
---
  Firefox does not support runtime.getPackageDirectoryEntry
>     "getPackageDirectoryEntry": {
379a415,418
  Firefox does not support runtime.restartAfterDelay
>     "restartAfterDelay": {
>       "minArgs": 1,
>       "maxArgs": 1
>     },
416a456,459
  Firefox does not define storage.management.clear/remove/set.
  Chrome does, because it re-uses the same class for all storage APIs.
>       "clear": {
>         "minArgs": 0,
>         "maxArgs": 0
>       },
423a467,474
>       },
>       "remove": {
>         "minArgs": 1,
>         "maxArgs": 1
>       },
>       "set": {
>         "minArgs": 1,
>         "maxArgs": 1
477a529,532
  Firefox does not support tabs.getAllInWindow
  (MDN currently says that it does, but that is wrong and I will submit a fix for that)
  Chrome has deprecated it in favor of tabs.query.
>     "getAllInWindow": {
>       "minArgs": 0,
>       "maxArgs": 1
>     },
481a537,540
  Firefox does not support tabs.getSelected
  Chrome has deprecated it in favor of tabs.query.
>     "getSelected": {
>       "minArgs": 0,
>       "maxArgs": 1
>     },
514,517d572
  Chrome does currently not support tabs.removeCSS
  It may be added in the future - https://crbug.com/608854
<     "removeCSS": {
<       "minArgs": 1,
<       "maxArgs": 2
<     },
521a577,580
  Firefox does not support tabs.sendRequest (which is deprecated by Chrome)
>     "sendRequest": {
>       "minArgs": 2,
>       "maxArgs": 2
>     },
```