### PR TITLE
feat: Add missing namespaces to metadata

### DIFF
--- a/api-metadata.json
+++ b/api-metadata.json
@@ -422,6 +422,20 @@
       "maxArgs": 1
     }
   },
+  "sessions": {
+    "getDevices": {
+      "minArgs": 0,
+      "maxArgs": 1
+    },
+    "getRecentlyClosed": {
+      "minArgs": 0,
+      "maxArgs": 1
+    },
+    "restore": {
+      "minArgs": 0,
+      "maxArgs": 1
+    }
+  },
   "storage": {
     "local": {
       "clear": {

--- a/api-metadata.json
+++ b/api-metadata.json
@@ -370,6 +370,24 @@
       "fallbackToNoCallback": true
     }
   },
+  "permissions": {
+    "contains": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "getAll": {
+      "minArgs": 0,
+      "maxArgs": 0
+    },
+    "remove": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "request": {
+      "minArgs": 1,
+      "maxArgs": 1
+    }
+  },
   "runtime": {
     "getBackgroundPage": {
       "minArgs": 0,

--- a/api-metadata.json
+++ b/api-metadata.json
@@ -93,6 +93,48 @@
       "maxArgs": 1
     }
   },
+  "browsingData": {
+    "remove": {
+      "minArgs": 2,
+      "maxArgs": 2
+    },
+    "removeCache": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "removeCookies": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "removeDownloads": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "removeFormData": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "removeHistory": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "removeLocalStorage": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "removePasswords": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "removePluginData": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "settings": {
+      "minArgs": 0,
+      "maxArgs": 0
+    }
+  },
   "commands": {
     "getAll": {
       "minArgs": 0,

--- a/api-metadata.json
+++ b/api-metadata.json
@@ -574,6 +574,12 @@
       "maxArgs": 2
     }
   },
+  "topSites": {
+    "get": {
+      "minArgs": 0,
+      "maxArgs": 0
+    }
+  },
   "webNavigation": {
     "getAllFrames": {
       "minArgs": 1,


### PR DESCRIPTION
I looked at the list of namespaces from https://github.com/mozilla/webextension-polyfill/pull/122#issuecomment-394020917 and added those which were missing to the metadata.

See the individual commit messages for more information.

With this PR (and #125), the metadata should be up-to-date, except for the `privacy` namespace.

Fixes #38