### PR TITLE
Use `delete window.browser` in `setupTestDOMWindow`

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -45,8 +45,7 @@ function setupTestDOMWindow(chromeObject, browserObject = undefined) {
     if (browserObject) {
       window.browser = browserObject;
     } else {
-      // TODO: change into `delete window.browser` once tmpvar/jsdom#1622 has been fixed.
-      window.browser = undefined;
+      delete window.browser;
     }
 
     const scriptEl = window.document.createElement("script");


### PR DESCRIPTION
Now that jsdom/jsdom#1622 has been fixed, and the minimum supported Node version for running the tests is 8 (which has the relevant fix), the relevant follow‑up from #2 can be applied.