### PR TITLE
Silence irrelevant browser.runtime.sendMessage error

### DIFF
--- a/test/test-runtime-onMessage.js
+++ b/test/test-runtime-onMessage.js
@@ -239,4 +239,24 @@ describe("browser-polyfill", () => {
       });
     });
   });
+
+  it("ignores a certain chrome.runtime.lastError", () => {
+    const fakeChrome = {
+      runtime: {
+        lastError: {
+          message: "The message port closed before a response was received.",
+        },
+        sendMessage: sinon.stub(),
+      },
+    };
+
+    return setupTestDOMWindow(fakeChrome).then(window => {
+      fakeChrome.runtime.sendMessage
+        .onFirstCall().callsArgWith(1, ["res1", "res2"]);
+
+      return window.browser.runtime.sendMessage("some_message").then(
+        (...args) => deepEqual(args, [undefined], "The error was ignored")
+      );
+    });
+  });
 });


### PR DESCRIPTION
Fixes #130.

See the comments in the code.

You can test here (by changing to `browser-polyfill-fork.js` in `manifest.json`): https://github.com/lydell/webextension-polyfill-messaging-issue