### PR TITLE
Fix the `\n` character preceding `echo` output in shell scripts

### DIFF
--- a/test/run-browsers-smoketests.sh
+++ b/test/run-browsers-smoketests.sh
@@ -1,5 +1,7 @@
-echo "\nTest webextension-polyfill on real browsers"
-echo "============================================"
+#!/bin/bash
+echo ""
+echo "Test webextension-polyfill on real browsers"
+echo "==========================================="
 
 export PATH=$PATH:./node_modules/.bin/
 
@@ -7,8 +9,10 @@ export PATH=$PATH:./node_modules/.bin/
 ## because Chrome doesn't currently support the extensions in headless mode)
 export HEADLESS=1
 
-echo "\nRun smoketests on Chrome"
+echo ""
+echo "Run smoketests on Chrome"
 TEST_BROWSER_TYPE=chrome npm run test-integration | tap-nirvana
 
-echo "\nRun smoketests on Firefox"
+echo ""
+echo "Run smoketests on Firefox"
 TEST_BROWSER_TYPE=firefox npm run test-integration | tap-nirvana

--- a/test/run-module-bundlers-smoketests.sh
+++ b/test/run-module-bundlers-smoketests.sh
@@ -1,10 +1,13 @@
-echo "\nTest webextension-polyfill bundled with webpack"
+#!/bin/bash
+echo ""
+echo "Test webextension-polyfill bundled with webpack"
 echo "==============================================="
 
 webpack --mode production --entry ./test/fixtures/bundle-entrypoint.js --output /tmp/webpack-bundle.js
 TEST_BUNDLED_POLYFILL=/tmp/webpack-bundle.js npm run test
 
-echo "\nTest webextension-polyfill bundled with browserify"
+echo ""
+echo "Test webextension-polyfill bundled with browserify"
 echo "=================================================="
 
 browserify test/fixtures/bundle-entrypoint.js > /tmp/browserify-bundle.js


### PR DESCRIPTION
This fixes the `\n` character sequence preceding all `echo` output in the shell scripts:
eg.: https://travis-ci.org/mozilla/webextension-polyfill/builds/394310210#L2181