### PR TITLE
fix: sendMessage promise should resolve to undefined when no listeners reply

### DIFF
--- a/test/fixtures/runtime-messaging-extension/background.js
+++ b/test/fixtures/runtime-messaging-extension/background.js
@@ -45,6 +45,9 @@ browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     case "test - sendMessage with listener callback throws":
       throw new Error("listener throws");
 
+    case "test - sendMessage and no listener answers":
+      return undefined;
+
     default:
       return Promise.resolve(
         `Unxpected message received by the background page: ${JSON.stringify(msg)}\n`);
@@ -52,6 +55,10 @@ browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 });
 
 browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg === "test - sendMessage and no listener answers") {
+    return undefined;
+  }
+
   setTimeout(() => {
     sendResponse("second listener reply");
   }, 100);

--- a/test/fixtures/runtime-messaging-extension/content.js
+++ b/test/fixtures/runtime-messaging-extension/content.js
@@ -75,3 +75,8 @@ test("sendMessage with listener callback throws", async (t) => {
     t.equal(err.message, "listener throws", "Got an error with the expected message");
   }
 });
+
+test("sendMessage and no listener answers", async (t) => {
+  const reply = await browser.runtime.sendMessage("test - sendMessage and no listener answers");
+  t.equal(reply, undefined, "Got undefined reply as expected");
+});


### PR DESCRIPTION
This PR contains the changes from #131 with the addition of some small tweaks (from the last review on #131) and an additional integration test (to check that the behavior of the polyfill in Chrome is the same of the one on Firefox with the native promised APIs).

Fixes #130