### PR TITLE
Minify compile time constants during build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,6 +44,12 @@ module.exports = function(grunt) {
                 "timestamp": "<%= grunt.template.today() %>",
               },
             },
+            {
+              match: /const ([A-Z$_][A-Z0-9$_]*) = `([^`${}]*)`\.replace\(\/([^/]+)\/(\w*), "([^"]+)"\).trim\(\);/g,
+              replacement: (match, constant, text, regexp, flags, replace) => {
+                return `const ${constant} = ${JSON.stringify(text.replace(RegExp(regexp, flags), replace).trim())};`;
+              },
+            },
           ],
         },
         files: [


### PR DESCRIPTION
Previously `SEND_RESPONSE_DEPRECATION_WARNING` would end up as:
```javascript
  const SEND_RESPONSE_DEPRECATION_WARNING = `
      Returning a Promise is the preferred way to send a reply from an
      onMessage/onMessageExternal listener, as the sendResponse will be
      removed from the specs (See
      https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/onMessage)
    `.replace(/\s+/g, " ").trim();
```
in both the built and minified distribution files, which adds unnecessary start-up overhead where the `/\s+/g` regular expression has to be compiled and executed, followed by trimming the string.

This instead performs such process during the build, which provides a few milliseconds of start-up time per extension which uses this polyfill, which adds up for a lot of extensions, especially ones with an event page, where the polyfill has to be loaded and executed every time the extension handles an event.