### PR TITLE
chore: Use correct node_modules/ in shell script

### DIFF
--- a/test/run-browsers-smoketests.sh
+++ b/test/run-browsers-smoketests.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -eo pipefail
 
+DIRNAME=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
+export PATH=$PATH:$DIRNAME/node_modules/.bin/
+
 echo ""
 echo "Test webextension-polyfill on real browsers"
 echo "==========================================="
-
-export PATH=$PATH:./node_modules/.bin/
 
 ## HEADLESS=1 Enable the headless mode (currently used only on Firefox
 ## because Chrome doesn't currently support the extensions in headless mode)

--- a/test/run-module-bundlers-smoketests.sh
+++ b/test/run-module-bundlers-smoketests.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eo pipefail
 
+DIRNAME=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
+export PATH=$PATH:$DIRNAME/node_modules/.bin/
+
 echo ""
 echo "Test webextension-polyfill bundled with webpack"
 echo "==============================================="


### PR DESCRIPTION
Use an absolute path so that the shell scripts use the expected node_modules directory (at the repository root) instead of whatever "node_modules" directory is in the current directory.