### PR TITLE
chore: Replace post-processed warning message with single-line string literal

### DIFF
--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -8,12 +8,7 @@
 
 if (typeof browser === "undefined") {
   const CHROME_SEND_MESSAGE_CALLBACK_NO_RESPONSE_MESSAGE = "The message port closed before a response was received.";
-  const SEND_RESPONSE_DEPRECATION_WARNING = `
-      Returning a Promise is the preferred way to send a reply from an
-      onMessage/onMessageExternal listener, as the sendResponse will be
-      removed from the specs (See
-      https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/onMessage)
-    `.replace(/\s+/g, " ").trim();
+  const SEND_RESPONSE_DEPRECATION_WARNING = "Returning a Promise is the preferred way to send a reply from an onMessage/onMessageExternal listener, as the sendResponse will be removed from the specs (See https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage)";
 
   // Wrapping the bulk of this polyfill in a one-time-use function is a minor
   // optimization for Firefox. Since Spidermonkey does not fully parse the


### PR DESCRIPTION
See @rpl’s comment in https://github.com/mozilla/webextension-polyfill/pull/142#issuecomment-405595998.