### PR TITLE
docs(README): Added reminder to include browser-polyfill.js before other bg scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ and linked to the github releases:
 ## Basic Setup
 
 In order to use the polyfill, it must be loaded into any context where `browser` APIs are accessed. The most common cases
-are background and content scripts, which can be specified in `manifest.json`:
+are background and content scripts, which can be specified in `manifest.json` (make sure to include the `browser-polyfill.js` script before any other scripts that use it):
 
 ```javascript
 {


### PR DESCRIPTION
Chrome 70.0.3538.77 did not find `browser` if the polyfill was loaded last/second (using [the `favorite-color` extension](https://github.com/mdn/webextensions-examples/tree/master/favourite-colour))