### PR TITLE
feat: Add schema and type definition for `api‑metadata.json`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -429,7 +429,7 @@
     "sort-vars": 0,
 
     // Require a space immediately following the // in a line comment.
-    "spaced-comment": [2, "always"],
+    "spaced-comment": [2, "always", { "markers": ["/"] }],
 
     // Require "use strict" to be defined globally in the script.
     "strict": [0, "global"],

--- a/api-metadata.schema.json
+++ b/api-metadata.schema.json
@@ -1,0 +1,59 @@
+{
+  "definitions": {
+
+    "function_metadata": {
+      "type": "object",
+      "properties": {
+        "minArgs": {
+          "description": "The minimum number of arguments which must be passed to the function. If called with fewer than this number of arguments, the wrapper will raise an exception.",
+          "type": "number"
+        },
+        "maxArgs": {
+          "description": "The maximum number of arguments which may be passed to the function. If called with more than this number of arguments, the wrapper will raise an exception.",
+          "type": "number"
+        },
+        "fallbackToNoCallback": {
+          "description": "If the function doesn't take a callback parameter in some browsers and throws an error when a callback is passed.",
+          "type": "boolean"
+        },
+        "noCallback": {
+          "description": "Set when `fallbackToNoCallback` is set and this browser doesn't support callbacks for this function.\nMUST NOT BE SET IN api-metadata.json.",
+          "type": "boolean"
+        },
+        "singleCallbackArg": {
+          "description": "If the function callback takes only one parameter in some browsers.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "minArgs",
+        "maxArgs"
+      ],
+      "not": {
+        "anyOf": [
+          {"required": ["noCallback"]}
+        ]
+      },
+      "additionalProperties": false
+    },
+
+    "namespace_metadata": {
+      "type": "object",
+      "not": {
+        "anyOf": [
+          {"required": ["minArgs"]},
+          {"required": ["maxArgs"]}
+        ]
+      },
+      "additionalProperties": {
+        "anyOf": [
+          { "$ref": "#/definitions/function_metadata" },
+          { "$ref": "#/definitions/namespace_metadata" }
+        ]
+      }
+    }
+
+  },
+
+  "$ref": "#/definitions/namespace_metadata"
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,36 @@
+
+declare interface FunctionMetadata {
+  /**
+   * The minimum number of arguments which must be passed to the
+   * function. If called with fewer than this number of arguments,
+   * the wrapper will raise an exception.
+   */
+  minArgs: number;
+
+  /**
+   * The maximum number of arguments which may be passed to the
+   * function. If called with more than this number of arguments,
+   * the wrapper will raise an exception.
+   */
+  maxArgs: number;
+
+  /**
+   * If the function doesn't take a callback parameter in some browsers
+   * and throws an error when a callback is passed.
+   */
+  fallbackToNoCallback?: boolean;
+
+  /**
+   * Set when `fallbackToNoCallback` is set and this browser doesn't
+   * support callbacks for this function.
+   */
+  noCallback?: boolean;
+
+  /**
+   * If the function callback takes only one parameter in some browsers.
+   */
+  singleCallbackArg?: boolean;
+}
+
+declare interface NamespaceMetadata extends Record<string, NamespaceMetadata | FunctionMetadata> {
+}


### PR DESCRIPTION
This adds a&nbsp;JSON&nbsp;Schema and a&nbsp;TypeScript definition file for&nbsp;<code>api&#x2011;metadata.json</code>.

## Additional changes:
- Updates JSDoc comments to&nbsp;make use of&nbsp;the&nbsp;new&nbsp;TypeScript definition file.

## To&nbsp;do:
- [ ] Use `ajv` and <code>better&#x2011;ajv&#x2011;errors</code> to&nbsp;validate <code>api&#x2011;metadata.json</code> against <code>api&#x2011;metadata.schema.json</code>