### PR TITLE
fix: browser.devtools.inspectedWindow.eval promise should always resolve to an array

### DIFF
--- a/api-metadata.json
+++ b/api-metadata.json
@@ -207,7 +207,8 @@
     "inspectedWindow": {
       "eval": {
         "minArgs": 1,
-        "maxArgs": 2
+        "maxArgs": 2,
+        "singleCallbackArg": false
       }
     },
     "panels": {

--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -93,7 +93,13 @@ if (typeof browser === "undefined" || Object.getPrototypeOf(browser) !== Object.
         if (extensionAPIs.runtime.lastError) {
           promise.reject(extensionAPIs.runtime.lastError);
         } else if (metadata.singleCallbackArg || callbackArgs.length <= 1) {
-          promise.resolve(callbackArgs[0]);
+          if (metadata.singleCallbackArg === false) {
+            // Pass the callback arguments as an array even if its length is <= 1
+            // when explicitly requested by the api metadata.
+            promise.resolve(callbackArgs);
+          } else {
+            promise.resolve(callbackArgs[0]);
+          }
         } else {
           promise.resolve(callbackArgs);
         }

--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -92,14 +92,9 @@ if (typeof browser === "undefined" || Object.getPrototypeOf(browser) !== Object.
       return (...callbackArgs) => {
         if (extensionAPIs.runtime.lastError) {
           promise.reject(extensionAPIs.runtime.lastError);
-        } else if (metadata.singleCallbackArg || callbackArgs.length <= 1) {
-          if (metadata.singleCallbackArg === false) {
-            // Pass the callback arguments as an array even if its length is <= 1
-            // when explicitly requested by the api metadata.
-            promise.resolve(callbackArgs);
-          } else {
-            promise.resolve(callbackArgs[0]);
-          }
+        } else if (metadata.singleCallbackArg ||
+                   (callbackArgs.length <= 1 && metadata.singleCallbackArg !== false)) {
+          promise.resolve(callbackArgs[0]);
         } else {
           promise.resolve(callbackArgs);
         }

--- a/test/fixtures/devtools-extension/background.js
+++ b/test/fixtures/devtools-extension/background.js
@@ -1,0 +1,12 @@
+let onDevToolsPageLoaded = new Promise(resolve => {
+  const listener = () => {
+    browser.runtime.onConnect.removeListener(listener);
+    resolve();
+  };
+  browser.runtime.onConnect.addListener(listener);
+});
+
+browser.runtime.onMessage.addListener(async msg => {
+  await onDevToolsPageLoaded;
+  return browser.runtime.sendMessage(msg);
+});

--- a/test/fixtures/devtools-extension/content.js
+++ b/test/fixtures/devtools-extension/content.js
@@ -1,0 +1,30 @@
+test("devtools.inspectedWindow.eval resolved with an error result", async (t) => {
+  const {evalResult} = await browser.runtime.sendMessage({
+    apiMethod: "devtools.inspectedWindow.eval",
+    params: ["throw new Error('fake error');"],
+  });
+
+  t.ok(Array.isArray(evalResult), "devtools.inspectedWindow.eval should resolve to an array");
+
+  t.equal(evalResult[0], navigator.userAgent.includes("Firefox/") ? undefined : null,
+          "the first element should be null (on chrome) or undefined (on firefox)");
+
+  t.ok(evalResult[1].isException, "the second element should represent an exception");
+  t.ok(evalResult[1].value && evalResult[1].value.includes("fake error"),
+       "the second element value property should include the expected error message");
+});
+
+test("devtools.inspectedWindow.eval resolved without an error result", async (t) => {
+  const {evalResult} = await browser.runtime.sendMessage({
+    apiMethod: "devtools.inspectedWindow.eval",
+    params: ["[document.documentElement.localName]"],
+  });
+
+  t.ok(Array.isArray(evalResult), "devtools.inspectedWindow.eval should resolve to an array");
+
+  if (navigator.userAgent.includes("Firefox/")) {
+    t.deepEqual(evalResult, [["html"], undefined], "got the expected values in the array");
+  } else {
+    t.deepEqual(evalResult, [["html"]], "got the expected values in the array");
+  }
+});

--- a/test/fixtures/devtools-extension/devtools_page.html
+++ b/test/fixtures/devtools-extension/devtools_page.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="browser-polyfill.js"></script>
+        <script src="devtools_page.js"></script>
+    </head>
+</html>

--- a/test/fixtures/devtools-extension/devtools_page.js
+++ b/test/fixtures/devtools-extension/devtools_page.js
@@ -4,11 +4,11 @@ browser.runtime.onMessage.addListener(async msg => {
   switch (msg.apiMethod) {
     case "devtools.inspectedWindow.eval": {
       const evalResult = await browser.devtools.inspectedWindow.eval(...msg.params);
-      return Promise.resolve({evalResult});
+      return {evalResult};
     }
   }
 
-  return Promise.reject(`devtools_page received an unxpected message: ${msg}`);
+  throw new Error(`devtools_page received an unxpected message: ${msg}`);
 });
 
 browser.runtime.connect({name: "devtools_page"});

--- a/test/fixtures/devtools-extension/devtools_page.js
+++ b/test/fixtures/devtools-extension/devtools_page.js
@@ -1,0 +1,14 @@
+console.log("devtools page loaded");
+
+browser.runtime.onMessage.addListener(async msg => {
+  switch (msg.apiMethod) {
+    case "devtools.inspectedWindow.eval": {
+      const evalResult = await browser.devtools.inspectedWindow.eval(...msg.params);
+      return Promise.resolve({evalResult});
+    }
+  }
+
+  return Promise.reject(`devtools_page received an unxpected message: ${msg}`);
+});
+
+browser.runtime.connect({name: "devtools_page"});

--- a/test/fixtures/devtools-extension/manifest.json
+++ b/test/fixtures/devtools-extension/manifest.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 2,
+  "name": "test-extension-devtools-api",
+  "version": "0.1",
+  "description": "test-extension-devtools-api",
+  "content_scripts": [
+    {
+      "matches": [
+        "http://localhost/*"
+      ],
+      "js": [
+        "browser-polyfill.js",
+        "tape.js",
+        "content.js"
+      ],
+      "run_at": "document_end"
+    }
+  ],
+  "permissions": [],
+  "background": {
+    "scripts": [
+      "browser-polyfill.js",
+      "background.js"
+    ]
+  },
+  "devtools_page": "devtools_page.html"
+}

--- a/test/integration/test-extensions-in-browser.js
+++ b/test/integration/test-extensions-in-browser.js
@@ -26,3 +26,9 @@ defineExtensionTests({
   description: "Instance of BrowserSetting API",
   extensions: ["privacy-setting-extension"],
 });
+
+defineExtensionTests({
+  description: "browser.devtools",
+  extensions: ["devtools-extension"],
+  openDevTools: true,
+});


### PR DESCRIPTION
This PR includes the changes needed to ensure that browser.devtools.inspectedWindow.eval returned promise is always resolved to an array (fix #168), and a new integration test to verify it as part of the automated tests.