### PR TITLE
test(devtools): Fix intermittent DevTools API test timeout

### DIFF
--- a/test/fixtures/devtools-extension/content.js
+++ b/test/fixtures/devtools-extension/content.js
@@ -1,4 +1,6 @@
-test("devtools.inspectedWindow.eval resolved with an error result", async (t) => {
+test("devtools.inspectedWindow.eval resolved with an error result", {
+  timeout: 5000,
+}, async (t) => {
   const {evalResult} = await browser.runtime.sendMessage({
     apiMethod: "devtools.inspectedWindow.eval",
     params: ["throw new Error('fake error');"],
@@ -14,7 +16,9 @@ test("devtools.inspectedWindow.eval resolved with an error result", async (t) =>
        "the second element value property should include the expected error message");
 });
 
-test("devtools.inspectedWindow.eval resolved without an error result", async (t) => {
+test("devtools.inspectedWindow.eval resolved without an error result", {
+  timeout: 5000,
+}, async (t) => {
   const {evalResult} = await browser.runtime.sendMessage({
     apiMethod: "devtools.inspectedWindow.eval",
     params: ["[document.documentElement.localName]"],

--- a/test/fixtures/tape-standalone.js
+++ b/test/fixtures/tape-standalone.js
@@ -9,50 +9,31 @@ if (navigator.userAgent.includes("Chrome/")) {
   browser = "Firefox";
 }
 
-function getArgs(/* desc, options, fn */) {
-  let desc = "(anonymous)";
-  // By setting `timeout` to `0` here, we are allowing V8 to consider
-  // it a to have a signature of `{timeout: number}` instead of `{}`
-  // with a `timeout` property, which is easier on the C++ portion.
-  let options = {timeout: 0};
-  /** @type {function(import("tape").Test):void|Promise<void>} */
-  let fn;
-
-  for (let i = 0, arg; i < arguments.length; i++) {
-    arg = arguments[i];
-    switch (typeof arg) {
-      case "string":
-        desc = arg;
-        break;
-      case "function":
-        fn = arg;
-        break;
-      case "object":
-        Object.assign(options, arg);
-        break;
-    }
-  }
-
-  if (!options.timeout) {
-    options.timeout = DEFAULT_TIMEOUT;
-  }
-
-  return {
-    desc,
-    options,
-    fn,
-  };
-}
-
 // Export as a global a wrapped test function which enforces a timeout by default.
 // eslint-disable-next-line
 /**
- * @param {string} [desc]
- * @param {object} [options]
+ * @param {string} desc
+ * @param {import("tape").TestOptions|null} [options]
  * @param {(test: import("tape").Test) => void|Promise<void>} fn
  */
 window.test = (desc, options, fn) => {
-  ({desc, options, fn} = getArgs(desc, options, fn));
+  if (typeof options === "function") {
+    // Allow swapping options with fn
+    if (typeof fn === "object" && fn) {
+      let tmp = fn;
+      fn = options;
+      options = tmp;
+    } else {
+      fn = options;
+      options = undefined;
+    }
+  }
+
+  options = {
+    timeout: DEFAULT_TIMEOUT,
+    ...options,
+  };
+
   tape(`${desc} (${browser})`, options, async (t) => {
     await fn(t);
   });

--- a/test/fixtures/tape-standalone.js
+++ b/test/fixtures/tape-standalone.js
@@ -15,7 +15,7 @@ function getArgs(/* desc, options, fn */) {
   // it a to have a signature of `{timeout: number}` instead of `{}`
   // with a `timeout` property, which is easier on the C++ portion.
   let options = {timeout: 0};
-  /** @type {function(any):void|Promise<void>} */
+  /** @type {function(import("tape").Test):void|Promise<void>} */
   let fn;
 
   for (let i = 0, arg; i < arguments.length; i++) {
@@ -33,7 +33,7 @@ function getArgs(/* desc, options, fn */) {
     }
   }
 
-  if (!options.timeout || options.timeout < DEFAULT_TIMEOUT) {
+  if (!options.timeout) {
     options.timeout = DEFAULT_TIMEOUT;
   }
 
@@ -45,10 +45,11 @@ function getArgs(/* desc, options, fn */) {
 }
 
 // Export as a global a wrapped test function which enforces a timeout by default.
+// eslint-disable-next-line
 /**
  * @param {string} [desc]
  * @param {object} [options]
- * @param {function(any):void|Promise<void>} fn
+ * @param {(test: import("tape").Test) => void|Promise<void>} fn
  */
 window.test = (desc, options, fn) => {
   ({desc, options, fn} = getArgs(desc, options, fn));

--- a/test/fixtures/tape-standalone.js
+++ b/test/fixtures/tape-standalone.js
@@ -10,19 +10,23 @@ if (navigator.userAgent.includes("Chrome/")) {
 }
 
 // Export as a global a wrapped test function which enforces a timeout by default.
-// eslint-disable-next-line
 /**
  * @param {string} desc
- * @param {import("tape").TestOptions|null} [options]
- * @param {(test: import("tape").Test) => void|Promise<void>} fn
+ *        The test description
+ * @param {object} [options]
+ *        The test options, can be omitted.
+ * @param {number} [options.timeout=DEFAULT_TIMEOUT]
+ *        The time after which the test fails automatically, unless it has already passed.
+ * @param {boolean} [options.skip]
+ *        Whether the test case should be skipped.
+ * @param {function(tape.Test):void|Promise<void>} fn
+ *        The test case function, takes the test object as a callback.
  */
 window.test = (desc, options, fn) => {
   if (typeof options === "function") {
     // Allow swapping options with fn
     if (typeof fn === "object" && fn) {
-      let tmp = fn;
-      fn = options;
-      options = tmp;
+      [fn, options] = [options, fn];
     } else {
       fn = options;
       options = undefined;

--- a/test/fixtures/tape-standalone.js
+++ b/test/fixtures/tape-standalone.js
@@ -9,14 +9,50 @@ if (navigator.userAgent.includes("Chrome/")) {
   browser = "Firefox";
 }
 
-// Export as a global a wrapped test function which enforces a timeout by default.
-window.test = (desc, options, fn) => {
-  if (!fn && typeof options === "function") {
-    fn = options;
-    options = undefined;
+function getArgs(/* desc, options, fn */) {
+  let desc = "(anonymous)";
+  // By setting `timeout` to `0` here, we are allowing V8 to consider
+  // it a to have a signature of `{timeout: number}` instead of `{}`
+  // with a `timeout` property, which is easier on the C++ portion.
+  let options = {timeout: 0};
+  /** @type {function(any):void|Promise<void>} */
+  let fn;
+
+  for (let i = 0, arg; i < arguments.length; i++) {
+    arg = arguments[i];
+    switch (typeof arg) {
+      case "string":
+        desc = arg;
+        break;
+      case "function":
+        fn = arg;
+        break;
+      case "object":
+        Object.assign(options, arg);
+        break;
+    }
   }
+
+  if (!options.timeout || options.timeout < DEFAULT_TIMEOUT) {
+    options.timeout = DEFAULT_TIMEOUT;
+  }
+
+  return {
+    desc,
+    options,
+    fn,
+  };
+}
+
+// Export as a global a wrapped test function which enforces a timeout by default.
+/**
+ * @param {string} [desc]
+ * @param {object} [options]
+ * @param {function(any):void|Promise<void>} fn
+ */
+window.test = (desc, options, fn) => {
+  ({desc, options, fn} = getArgs(desc, options, fn));
   tape(`${desc} (${browser})`, options, async (t) => {
-    t.timeoutAfter(DEFAULT_TIMEOUT);
     await fn(t);
   });
 };

--- a/test/fixtures/tape-standalone.js
+++ b/test/fixtures/tape-standalone.js
@@ -19,18 +19,13 @@ if (navigator.userAgent.includes("Chrome/")) {
  *        The time after which the test fails automatically, unless it has already passed.
  * @param {boolean} [options.skip]
  *        Whether the test case should be skipped.
- * @param {function(tape.Test):void|Promise<void>} fn
+ * @param {function(tape.Test):(void|Promise<void>)} fn
  *        The test case function, takes the test object as a callback.
  */
 window.test = (desc, options, fn) => {
   if (typeof options === "function") {
     // Allow swapping options with fn
-    if (typeof fn === "object" && fn) {
-      [fn, options] = [options, fn];
-    } else {
-      fn = options;
-      options = undefined;
-    }
+    [fn, options] = [options, fn];
   }
 
   options = {

--- a/test/fixtures/tape-standalone.js
+++ b/test/fixtures/tape-standalone.js
@@ -10,8 +10,12 @@ if (navigator.userAgent.includes("Chrome/")) {
 }
 
 // Export as a global a wrapped test function which enforces a timeout by default.
-window.test = (desc, fn) => {
-  tape(`${desc} (${browser})`, async (t) => {
+window.test = (desc, options, fn) => {
+  if (!fn && typeof options === "function") {
+    fn = options;
+    options = undefined;
+  }
+  tape(`${desc} (${browser})`, options, async (t) => {
     t.timeoutAfter(DEFAULT_TIMEOUT);
     await fn(t);
   });

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -165,6 +165,7 @@ test.onFailure(() => {
  * @param {string} parameters.description
  * @param {string[]} parameters.extensions
  * @param {boolean|string|string[]} [parameters.skip]
+ * @param {boolean} [parameters.openDevTools]
  */
 const defineExtensionTests = ({description, extensions, skip, openDevTools}) => {
   for (const extensionDirName of extensions) {
@@ -192,8 +193,8 @@ const defineExtensionTests = ({description, extensions, skip, openDevTools}) => 
           path.join(__dirname, "..", "fixtures", extensionDirName));
         const srcPolyfill = path.join(__dirname, "..", "..", "dist", "browser-polyfill.js");
 
-        const tmpDir = tmp.dirSync({unsafeCleanup: true});
-        const extensionPath = path.join(tmpDir.name, extensionDirName);
+        tempDir = tmp.dirSync({unsafeCleanup: true});
+        const extensionPath = path.join(tempDir.name, extensionDirName);
 
         cp("-rf", srcExtensionPath, extensionPath);
         cp("-f", srcPolyfill, extensionPath);


### PR DESCRIPTION
This fixes the intermittent timeout issue that caused a #171 test to fail.

## External links:
- https://travis-ci.org/mozilla/webextension-polyfill/builds/487787360#L950