### PR TITLE
chore: Add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,9 @@ root = true
 [*]
 end_of_line = lf
 charset = utf-8
-indent_style = space
-indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.{eslintrc,html,js,json,md}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This adds an [EditorConfig] file, so that the project’s indentation style is maintained without needing to reconfigure the editor.

---

[EditorConfig]: https://editorconfig.org

review?(@Rob--W)