### PR TITLE
feat: add type declaration file for TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export default browser;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A lightweight polyfill library for Promise-based WebExtension APIs in Chrome.",
   "main": "dist/browser-polyfill.js",
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "repository": {
     "type": "git",
@@ -49,6 +50,9 @@
     "tape": "^4.9.1",
     "tape-async": "^2.3.0",
     "tmp": "0.0.33"
+  },
+  "peerDependencies": {
+    "@types/firefox-webext-browser": ">=58.0.0"
   },
   "nyc": {
     "reporter": [


### PR DESCRIPTION
Add `index.d.ts` for typing is really helpful for TypeScript Developers.
Build and locally install for type checking was tested.

![image](https://user-images.githubusercontent.com/4502661/62070162-8808c900-b26c-11e9-9915-23666758d5b4.png)

