### PR TITLE
chore(deps): Updated chromedriver to version 78.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-preset-es2017": "^6.24.1",
     "browserify": "^16.2.2",
     "chai": "^3.5.0",
-    "chromedriver": "^76.0.0",
+    "chromedriver": "^78.0.1",
     "cross-env": "^5.2.0",
     "eslint": "^3.9.1",
     "finalhandler": "^1.1.0",


### PR DESCRIPTION
Fix chromedriver failure triggered by Travis CI. See -> https://travis-ci.org/mozilla/webextension-polyfill/builds/604662201#L568