### PR TITLE
chore: Update npm dev dependencies (besides jsdom, and the ones related to babel)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "selenium-webdriver": "^4.0.0-alpha.1",
     "serve-static": "^1.13.1",
     "shelljs": "^0.8.2",
-    "sinon": "^1.17.6",
+    "sinon": "^7.5.0",
     "tap-nirvana": "^1.0.8",
     "tape": "^4.9.1",
     "tape-async": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt": "^1.0.1",
     "grunt-babel": "^6.0.0",
     "grunt-contrib-concat": "^1.0.1",
-    "grunt-coveralls": "^1.0.1",
+    "grunt-coveralls": "^2.0.0",
     "grunt-replace": "^1.0.1",
     "gruntify-eslint": "^5.0.0",
     "istanbul-lib-instrument": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-babili": "^0.0.10",
     "babel-preset-es2017": "^6.24.1",
     "browserify": "^16.2.2",
-    "chai": "^3.5.0",
+    "chai": "^4.2.0",
     "chromedriver": "^78.0.1",
     "cross-env": "^6.0.3",
     "eslint": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "tap-nirvana": "^1.0.8",
     "tape": "^4.9.1",
     "tape-async": "^2.3.0",
-    "tmp": "0.0.33"
+    "tmp": "^0.1.0"
   },
   "nyc": {
     "reporter": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gruntify-eslint": "^4.0.0",
     "istanbul-lib-instrument": "^3.3.0",
     "jsdom": "^9.6.0",
-    "mocha": "^3.1.0",
+    "mocha": "^6.2.2",
     "nyc": "^14.1.1",
     "selenium-webdriver": "^4.0.0-alpha.1",
     "serve-static": "^1.13.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "async-wait-until": "^1.1.5",
     "babel-core": "^6.26.3",
-    "babel-eslint": "^8.0.1",
+    "babel-eslint": "^10.0.3",
     "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "babel-preset-babili": "^0.0.10",
     "babel-preset-es2017": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "istanbul-lib-instrument": "^3.3.0",
     "jsdom": "^9.6.0",
     "mocha": "^3.1.0",
-    "nyc": "^8.3.1",
+    "nyc": "^14.1.1",
     "selenium-webdriver": "^4.0.0-alpha.1",
     "serve-static": "^1.13.1",
     "shelljs": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt-coveralls": "^1.0.1",
     "grunt-replace": "^1.0.1",
     "gruntify-eslint": "^4.0.0",
-    "istanbul-lib-instrument": "^1.1.3",
+    "istanbul-lib-instrument": "^3.3.0",
     "jsdom": "^9.6.0",
     "mocha": "^3.1.0",
     "nyc": "^8.3.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-contrib-concat": "^1.0.1",
     "grunt-coveralls": "^1.0.1",
     "grunt-replace": "^1.0.1",
-    "gruntify-eslint": "^4.0.0",
+    "gruntify-eslint": "^5.0.0",
     "istanbul-lib-instrument": "^3.3.0",
     "jsdom": "^9.6.0",
     "mocha": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "browserify": "^16.2.2",
     "chai": "^3.5.0",
     "chromedriver": "^78.0.1",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "eslint": "^6.6.0",
     "finalhandler": "^1.1.0",
     "geckodriver": "^1.11.2",

--- a/test/test-async-functions.js
+++ b/test/test-async-functions.js
@@ -212,8 +212,8 @@ describe("browser-polyfill", () => {
           // Call pageAction.show and hide again to ensure that only after a successfull
           // API call the wrapper will always call the API method without the callback parameter.
 
-          fakeChrome.pageAction.show.reset();
-          fakeChrome.pageAction.hide.reset();
+          fakeChrome.pageAction.show.resetHistory();
+          fakeChrome.pageAction.hide.resetHistory();
 
           const secondPageActionShowPromise = browser.pageAction.show(1).catch(err => err);
           const secondPageActionHidePromise = browser.pageAction.hide(undefined).catch(err => err);


### PR DESCRIPTION
This PR covers the npm dependencies that are outdated and can be updated without any actual change, or with just a very small amount of changes (like the ones applied to update sinon to version 7.5.0).

The following outdated deps are not being updated yet in this PR:
```
Package              Current  Wanted  Latest  Location
babel-preset-babili   0.0.10  0.0.10   0.1.4  webextension-polyfill
grunt-babel            6.0.0   6.0.0   8.0.0  webextension-polyfill
jsdom                 9.12.0  9.12.0  15.2.1  webextension-polyfill
```

jsdom 15.2.1 is not yet updated in this PR because there are backward incompatible changes to the jsdom APIs we use in our test harness, I'm going to take care of that in a separate PR that also port that parts to the new jsdom API.

grunt-babel 8.0.0 isn't yet updated because depends from babel 7, and so I'm deferring it to a separate PRs (especially because it turned out that, while updating this repo to babel 7 is simple enough, there are some differences in how @babel/transform-umd-modules wraps the module which are not working as in the previous version and the browser API object isn't being exported as it should and all the tests are failing, as expected given that the UMD module isn't being generated correctly)

babel-preset-babili has not been updated because it has been more recently renamed to babel-preset-minify in more recent version, but it requires to also update the other babel dependencies and it would make sense to update to babel-preset-minify along with updating babel.