### PR TITLE
Allowing devtools.panel.create accept up to 4 args

### DIFF
--- a/api-metadata.json
+++ b/api-metadata.json
@@ -214,7 +214,7 @@
     "panels": {
       "create": {
         "minArgs": 3,
-        "maxArgs": 3,
+        "maxArgs": 4,
         "singleCallbackArg": true
       }
     }


### PR DESCRIPTION
In Chrome, `devtools.panel.create` accepts 4 arguments:

https://developer.chrome.com/extensions/devtools_panels#method-create

While firefox only accepts 3:

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/create

Not sure how to address this inconsistency, but IMHO the arguments shouldn't be limited to 3.