### PR TITLE
fix(travis): Run tests with Node 10 instead of 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
 ## Some of the ES6 syntax used in the browser-polyfill sources is only supported on nodejs >= 6
 ## and the selenium-webdriver dependency used by the integration tests requires nodejs >= 8.
-- '8'
+## and the chromedriver dependency requires Node >= 10.
+- '10'
 
 script:
 - npm run build

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-preset-minify": "^0.5.1",
     "browserify": "^16.2.2",
     "chai": "^4.2.0",
-    "chromedriver": "^80.0.1",
+    "chromedriver": "^85.0.1",
     "cross-env": "^6.0.3",
     "eslint": "^6.6.0",
     "finalhandler": "^1.1.0",

--- a/test/fixtures/tabs-sendmessage-extension/content.js
+++ b/test/fixtures/tabs-sendmessage-extension/content.js
@@ -1,8 +1,19 @@
 test("tabs.sendMessage reject when sending to unknown tab id", async (t) => {
   const res = await browser.runtime.sendMessage("test-tabssendMessage-unknown-tabid");
+  let errorMessage = "Could not establish connection. Receiving end does not exist.";
+  const firefoxVersion = +(/Firefox\/([0-9]+)/.exec(navigator.userAgent) || ["", "0"])[1];
+  if (firefoxVersion === 79) {
+    // Value of error message regressed in:
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1665568
+    errorMessage = "Error: tab is null";
+  } else if (firefoxVersion >= 80) {
+    // Raw error message leaked until it got sanitized again with
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1655624
+    errorMessage = "An unexpected error occurred";
+  }
   t.deepEqual(res, {
     success: true,
     isRejected: true,
-    errorMessage: "Could not establish connection. Receiving end does not exist.",
+    errorMessage,
   }, "The background page got a rejection as expected");
 });


### PR DESCRIPTION
CI is currently failing because package.json refers chromedriver `^80.0.1`, which also matches 80.0.2.

In 80.0.2, chromedriver updated the `extract-zip` dependency:
https://github.com/giggio/node-chromedriver/commit/16151de4c7bd87ef952665deb95aa56ce3539948

extract-zip 2.0.0 has dropped support for Node <10, e.g. by using APIs that were introduced in Node 10:
https://github.com/maxogden/extract-zip/blob/v2.0.0/index.js#L11

which triggers the following error when run on earlier versions of Node:

```
> chromedriver@80.0.2 install /home/travis/build/mozilla/webextension-polyfill/node_modules/chromedriver
> node install.js

internal/util.js:214
    throw new errors.TypeError('ERR_INVALID_ARG_TYPE', 'original', 'function');
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "original" argument must be of type function
    at promisify (internal/util.js:214:11)
    at Object.<anonymous> (/home/travis/build/mozilla/webextension-polyfill/node_modules/extract-zip/index.js:11:18)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/travis/build/mozilla/webextension-polyfill/node_modules/chromedriver/install.js:14:20)
```

This commit fixes the issue by running tests with Node 10.
Node 8 had become end-of-life on 2019-12-31 anyway.
(and node-chromedriver started to officially require Node 10 starting with 83.0.0, in https://github.com/giggio/node-chromedriver/pull/263 )