### PR TITLE
fix: Corrected maxArgs for topSites.get

### DIFF
--- a/api-metadata.json
+++ b/api-metadata.json
@@ -606,7 +606,7 @@
   "topSites": {
     "get": {
       "minArgs": 0,
-      "maxArgs": 0
+      "maxArgs": 1
     }
   },
   "webNavigation": {


### PR DESCRIPTION
`topSites.get` method accepts an optional options argument. Although, polyfill throws an error when you invoke that method with options because maxArgs of method defined as 0 in meta-data file. This resolves problem by passing wrong validation on method argument count.

Ref: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/topSites/get