### PR TITLE
docs(README): Updated code in "Usage with webpack without bundling"

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,11 +203,11 @@ module.exports = {
   },
   */
   plugins: [
-    new CopyWebpackPlugin([
-      {
-        from: 'node_modules/webextension-polyfill/dist/browser-polyfill.js'
-      }
-    ])
+    new CopyWebpackPlugin({
+      patterns: [{
+        from: 'node_modules/webextension-polyfill/dist/browser-polyfill.js',
+      }],
+    })
   ]
 }
 ```


### PR DESCRIPTION
Usage of copy-webpack-plugin has been updated in [v6.0.6](https://github.com/webpack-contrib/copy-webpack-plugin/releases/tag/v6.0.0).