### PR TITLE
feat: Add more validation for browser apis

### DIFF
--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-if (typeof browser === "undefined" || Object.getPrototypeOf(browser) !== Object.prototype) {
+if (typeof chrome === "object" && chrome && chrome.runtime && chrome.runtime.id) {
   const CHROME_SEND_MESSAGE_CALLBACK_NO_RESPONSE_MESSAGE = "The message port closed before a response was received.";
   const SEND_RESPONSE_DEPRECATION_WARNING = "Returning a Promise is the preferred way to send a reply from an onMessage/onMessageExternal listener, as the sendResponse will be removed from the specs (See https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage)";
 
@@ -503,13 +503,11 @@ if (typeof browser === "undefined" || Object.getPrototypeOf(browser) !== Object.
     return wrapObject(extensionAPIs, staticWrappers, apiMetadata);
   };
 
-  if (typeof chrome != "object" || !chrome || !chrome.runtime || !chrome.runtime.id) {
-    throw new Error("This script should only be loaded in a browser extension.");
-  }
-
   // The build process adds a UMD wrapper around this file, which makes the
   // `module` variable available.
   module.exports = wrapAPIs(chrome);
-} else {
+} else if (typeof browser !== "undefined" && Object.getPrototypeOf(browser) === Object.prototype) {
   module.exports = browser;
+} else {
+  throw new Error("This script should only be loaded in a browser extension.");
 }

--- a/test/test-browser-global.js
+++ b/test/test-browser-global.js
@@ -24,14 +24,11 @@ describe("browser-polyfill", () => {
   });
 
   it("does not override the global browser namespace if it already exists", () => {
-    const fakeChrome = {
-      runtime: {lastError: null},
-    };
     const fakeBrowser = {
       mycustomns: {mybrowserkey: true},
     };
 
-    return setupTestDOMWindow(fakeChrome, fakeBrowser).then(window => {
+    return setupTestDOMWindow(null, fakeBrowser).then(window => {
       deepEqual(window.browser, fakeBrowser,
                 "The existing browser has not been wrapped");
     });


### PR DESCRIPTION
## Goal

Fix the polyfill might not work on the website which defined browser as an object in global scope. The original behavior only test browser is an object or not. However if a website has following code in chrome, then it would return `browser` immediately which makes this polyfill not wok.

```js
window.browser = window.Object();
```

## Changes

* Check chrome apis is valid extension apis first

## Limitation

Even though checking chrome apis is valid, website could also define a dummy `chrome.runtime.id` to make this polyfill broken. IMHO, the better way might be detecting the environment (chrome, firefox or etc) directly rather than check the global variable in the future.