### PR TITLE
fix: replace --output option of webpack

### DIFF
--- a/scripts/run-module-bundlers-smoketests.js
+++ b/scripts/run-module-bundlers-smoketests.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+const path = require("path");
 const shell = require("shelljs");
 
 let result = 0;
@@ -8,7 +9,10 @@ Test webextension-polyfill bundled with webpack
 ===============================================`);
 
 process.env.TEST_BUNDLED_POLYFILL = "/tmp/webpack-bundle.js";
-result = shell.exec(`webpack --mode production --entry ./test/fixtures/bundle-entrypoint.js --output ${process.env.TEST_BUNDLED_POLYFILL}`).code ||
+const webpackOutputDir = path.dirname(process.env.TEST_BUNDLED_POLYFILL);
+const webpackOutputFilename = path.basename(process.env.TEST_BUNDLED_POLYFILL);
+
+result = shell.exec(`webpack --mode production --entry ./test/fixtures/bundle-entrypoint.js --output-path ${webpackOutputDir} --output-filename ${webpackOutputFilename}`).code ||
   shell.exec("npm run test").code || result;
 
 console.log(`


### PR DESCRIPTION
Currently the build/test fails with the following output:

```
Test webextension-polyfill bundled with webpack
===============================================
[webpack-cli] Unknown argument: --output
[webpack-cli] Unknown argument: /tmp/webpack-bundle.js
? Which flags do you want to use? …
✔ --entry: The entry point(s) of your application e.g. ./src/main.js
✔ --config: Provide path to a webpack configuration file e.g. ./webpack.config.js
✔ --color: Enable/Disable colors on console
✔ --merge: Merge two or more configurations using webpack-merge e.g. -c ./webpack.config.js -c ./webpack.test.config.js --merge
✔ --progress: Print compilation progress during build
✔ --help: Outputs list of supported flags
✔ --output-path: Output location of the file generated by webpack e.g. ./dist/
```

Regressed by:
https://github.com/webpack/webpack-cli/pull/1855
https://github.com/webpack/webpack-cli/commit/2f36b9d858faedaf3a6adca10a529d9837c0dd24

`--output` has been renamed to `--output-path` (`-o` in both cases), but stopped supporting file names.
To output to a specific absolute path, `--output-path` and `--output-filename` must both be specified, with the directory in the former and the filename in the latter.