### PR TITLE
fix(test): fix expectation of tabs-sendmessage in Firefox + update chromedriver

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-preset-minify": "^0.5.1",
     "browserify": "^16.2.2",
     "chai": "^4.2.0",
-    "chromedriver": "^85.0.1",
+    "chromedriver": "^87.0.2",
     "cross-env": "^6.0.3",
     "eslint": "^6.6.0",
     "finalhandler": "^1.1.0",

--- a/test/fixtures/tabs-sendmessage-extension/content.js
+++ b/test/fixtures/tabs-sendmessage-extension/content.js
@@ -4,9 +4,11 @@ test("tabs.sendMessage reject when sending to unknown tab id", async (t) => {
   const firefoxVersion = +(/Firefox\/([0-9]+)/.exec(navigator.userAgent) || ["", "0"])[1];
   if (firefoxVersion === 79) {
     // Value of error message regressed in:
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1583484
+    // and got fixed in Firefox 83 in:
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1665568
     errorMessage = "Error: tab is null";
-  } else if (firefoxVersion >= 80) {
+  } else if (firefoxVersion >= 80 && firefoxVersion < 83) {
     // Raw error message leaked until it got sanitized again with
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1655624
     errorMessage = "An unexpected error occurred";


### PR DESCRIPTION
CI build is currently broken.

Surprisingly similar to #238: this PR updates the test expectation for a fixed regression in Firefox, and updated chromedriver.