### PR TITLE
chore: Removed unused async-wait-until dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@babel/core": "7.12.16",
     "@babel/preset-env": "7.12.16",
     "@babel/register": "7.12.13",
-    "async-wait-until": "1.2.6",
     "babel-eslint": "10.1.0",
     "babel-preset-minify": "0.5.1",
     "browserify": "17.0.0",


### PR DESCRIPTION
Supersedes #277.

Context: looking back to the repo history it looks that the async-wait-until dev dependency was originally used in the integration tests, before we migrated the integration tests to use selenium webdriver to let us run the same set of tests on both Chrome and Firefox. Once we migrated to selenium webdriver async-wait-until did become unused (the integrated tests setup.js module is currently using `driver.wait` for a purpose similar to what async-wait-until was originally used for).