### PR TITLE
fix: Reject with real Error instances like Firefox does

### DIFF
--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -95,7 +95,7 @@ if (typeof browser === "undefined" || Object.getPrototypeOf(browser) !== Object.
     const makeCallback = (promise, metadata) => {
       return (...callbackArgs) => {
         if (extensionAPIs.runtime.lastError) {
-          promise.reject(extensionAPIs.runtime.lastError);
+          promise.reject(new Error(extensionAPIs.runtime.lastError.message));
         } else if (metadata.singleCallbackArg ||
                    (callbackArgs.length <= 1 && metadata.singleCallbackArg !== false)) {
           promise.resolve(callbackArgs[0]);
@@ -484,7 +484,7 @@ if (typeof browser === "undefined" || Object.getPrototypeOf(browser) !== Object.
         if (extensionAPIs.runtime.lastError.message === CHROME_SEND_MESSAGE_CALLBACK_NO_RESPONSE_MESSAGE) {
           resolve();
         } else {
-          reject(extensionAPIs.runtime.lastError);
+          reject(new Error(extensionAPIs.runtime.lastError.message));
         }
       } else if (reply && reply.__mozWebExtensionPolyfillReject__) {
         // Convert back the JSON representation of the error into

--- a/test/fixtures/detect-existing-browser-api-object/content.js
+++ b/test/fixtures/detect-existing-browser-api-object/content.js
@@ -1,6 +1,6 @@
 /* global originalAPIObjects */
 
-test("browser api object in content script", (t) => {
+test("browser api object in content script", async (t) => {
   t.ok(browser && browser.runtime, "a global browser API object should be defined");
   t.ok(chrome && chrome.runtime, "a global chrome API object should be defined");
 
@@ -10,12 +10,27 @@ test("browser api object in content script", (t) => {
     // On Firefox, window is not the global object for content scripts, and so we expect window.browser to not
     // be defined.
     t.equal(window.browser, undefined, "window.browser is expected to be undefined on Firefox");
+
+    try {
+      await browser.storage.sync.set({a: 'a'.repeat(10000000)});
+      t.fail('It should throw when attempting to set an object over quota');
+    } catch (error) {
+      t.ok(error instanceof Error);
+    }
   } else {
     // Check that the polyfill has created a wrapped API namespace as expected.
     t.notEqual(browser.runtime, chrome.runtime, "browser.runtime and chrome.runtime should not be equal");
     // On chrome, window is the global object and so the polyfilled browser API should
     // be also equal to window.browser.
     t.equal(browser, window.browser, "browser and window.browser should be the same object");
+
+    chrome.storage.local.set({a: 'a'.repeat(10000000)}, () => {
+      t.ok(chrome.runtime.lastError, 'It should throw when attempting to set an object over quota');
+      t.equal(chrome.runtime.lastError.message, 'QUOTA_BYTES quota exceeded');
+      t.notOk(chrome.runtime.lastError instanceof Error);
+    });
+
+    t.end();
   }
 });
 

--- a/test/fixtures/detect-existing-browser-api-object/content.js
+++ b/test/fixtures/detect-existing-browser-api-object/content.js
@@ -42,7 +42,7 @@ test("error types", async (t) => {
       await browser.storage.sync.set({a: 'a'.repeat(10000000)});
       t.fail('It should throw when attempting to set an object over quota');
     } catch (error) {
-      t.equal(error.message, 'QUOTA_BYTES quota exceeded');
+      t.equal(error.message, 'The storage API will not work with a temporary addon ID. Please add an explicit addon ID to your manifest. For more information see https://mzl.la/3lPk1aE.');
       t.ok(error instanceof Error);
     }
   } else {

--- a/test/fixtures/detect-existing-browser-api-object/content.js
+++ b/test/fixtures/detect-existing-browser-api-object/content.js
@@ -38,7 +38,7 @@ test("error types", async (t) => {
   if (navigator.userAgent.includes("Firefox/")) {
     try {
       await browser.storage.sync.set({a: 'a'});
-      t.fail('It should throw when attempting to set an object over quota');
+      t.fail('It should throw when attempting to call storage.sync with a temporary addon ID');
     } catch (error) {
       t.equal(error.message, 'The storage API will not work with a temporary addon ID. Please add an explicit addon ID to your manifest. For more information see https://mzl.la/3lPk1aE.');
       t.ok(error instanceof Error);

--- a/test/fixtures/detect-existing-browser-api-object/content.js
+++ b/test/fixtures/detect-existing-browser-api-object/content.js
@@ -37,7 +37,7 @@ test("browser api object in background page", async (t) => {
 test("error types", async (t) => {
   if (navigator.userAgent.includes("Firefox/")) {
     try {
-      await browser.storage.sync.set({a: 'a'.repeat(10000000)});
+      await browser.storage.sync.set({a: 'a'});
       t.fail('It should throw when attempting to set an object over quota');
     } catch (error) {
       t.equal(error.message, 'The storage API will not work with a temporary addon ID. Please add an explicit addon ID to your manifest. For more information see https://mzl.la/3lPk1aE.');

--- a/test/fixtures/detect-existing-browser-api-object/content.js
+++ b/test/fixtures/detect-existing-browser-api-object/content.js
@@ -36,7 +36,6 @@ test("browser api object in background page", async (t) => {
 
 test("error types", async (t) => {
   if (navigator.userAgent.includes("Firefox/")) {
-    t.plan(2);
     try {
       await browser.storage.sync.set({a: 'a'.repeat(10000000)});
       t.fail('It should throw when attempting to set an object over quota');
@@ -45,11 +44,11 @@ test("error types", async (t) => {
       t.ok(error instanceof Error);
     }
   } else {
-    t.plan(3);
-    chrome.storage.local.set({a: 'a'.repeat(10000000)}, () => {
-      t.ok(chrome.runtime.lastError, 'It should throw when attempting to set an object over quota');
-      t.equal(chrome.runtime.lastError.message, 'QUOTA_BYTES quota exceeded');
-      t.notOk(chrome.runtime.lastError instanceof Error);
+    await new Promise(resolve => {
+      chrome.storage.local.set({a: 'a'.repeat(10000000)}, resolve);
     });
+    t.ok(chrome.runtime.lastError, 'It should throw when attempting to set an object over quota');
+    t.equal(chrome.runtime.lastError.message, 'QUOTA_BYTES quota exceeded');
+    t.notOk(chrome.runtime.lastError instanceof Error);
   }
 });

--- a/test/fixtures/detect-existing-browser-api-object/content.js
+++ b/test/fixtures/detect-existing-browser-api-object/content.js
@@ -35,9 +35,8 @@ test("browser api object in background page", async (t) => {
 });
 
 test("error types", async (t) => {
-  t.plan(3);
-
   if (navigator.userAgent.includes("Firefox/")) {
+    t.plan(2);
     try {
       await browser.storage.sync.set({a: 'a'.repeat(10000000)});
       t.fail('It should throw when attempting to set an object over quota');
@@ -46,6 +45,7 @@ test("error types", async (t) => {
       t.ok(error instanceof Error);
     }
   } else {
+    t.plan(3);
     chrome.storage.local.set({a: 'a'.repeat(10000000)}, () => {
       t.ok(chrome.runtime.lastError, 'It should throw when attempting to set an object over quota');
       t.equal(chrome.runtime.lastError.message, 'QUOTA_BYTES quota exceeded');

--- a/test/fixtures/detect-existing-browser-api-object/content.js
+++ b/test/fixtures/detect-existing-browser-api-object/content.js
@@ -1,6 +1,6 @@
 /* global originalAPIObjects */
 
-test("browser api object in content script", async (t) => {
+test("browser api object in content script", (t) => {
   t.ok(browser && browser.runtime, "a global browser API object should be defined");
   t.ok(chrome && chrome.runtime, "a global chrome API object should be defined");
 
@@ -10,27 +10,12 @@ test("browser api object in content script", async (t) => {
     // On Firefox, window is not the global object for content scripts, and so we expect window.browser to not
     // be defined.
     t.equal(window.browser, undefined, "window.browser is expected to be undefined on Firefox");
-
-    try {
-      await browser.storage.sync.set({a: 'a'.repeat(10000000)});
-      t.fail('It should throw when attempting to set an object over quota');
-    } catch (error) {
-      t.ok(error instanceof Error);
-    }
   } else {
     // Check that the polyfill has created a wrapped API namespace as expected.
     t.notEqual(browser.runtime, chrome.runtime, "browser.runtime and chrome.runtime should not be equal");
     // On chrome, window is the global object and so the polyfilled browser API should
     // be also equal to window.browser.
     t.equal(browser, window.browser, "browser and window.browser should be the same object");
-
-    chrome.storage.local.set({a: 'a'.repeat(10000000)}, () => {
-      t.ok(chrome.runtime.lastError, 'It should throw when attempting to set an object over quota');
-      t.equal(chrome.runtime.lastError.message, 'QUOTA_BYTES quota exceeded');
-      t.notOk(chrome.runtime.lastError instanceof Error);
-    });
-
-    t.end();
   }
 });
 
@@ -46,5 +31,25 @@ test("browser api object in background page", async (t) => {
   } else {
     t.ok(!reply.browserIsUnchanged, "browser API object should have been defined by the polyfill");
     t.ok(!reply.windowBrowserIsUnchanged, "window.browser API object should have been defined by the polyfill");
+  }
+});
+
+test("error types", async (t) => {
+  t.plan(3);
+
+  if (navigator.userAgent.includes("Firefox/")) {
+    try {
+      await browser.storage.sync.set({a: 'a'.repeat(10000000)});
+      t.fail('It should throw when attempting to set an object over quota');
+    } catch (error) {
+      t.equal(error.message, 'QUOTA_BYTES quota exceeded');
+      t.ok(error instanceof Error);
+    }
+  } else {
+    chrome.storage.local.set({a: 'a'.repeat(10000000)}, () => {
+      t.ok(chrome.runtime.lastError, 'It should throw when attempting to set an object over quota');
+      t.equal(chrome.runtime.lastError.message, 'QUOTA_BYTES quota exceeded');
+      t.notOk(chrome.runtime.lastError instanceof Error);
+    });
   }
 });

--- a/test/fixtures/detect-existing-browser-api-object/manifest.json
+++ b/test/fixtures/detect-existing-browser-api-object/manifest.json
@@ -6,6 +6,11 @@
   "background": {
     "page": "background.html"
   },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "addon@example.com"
+    }
+  },
   "content_scripts": [
     {
       "matches": [

--- a/test/fixtures/detect-existing-browser-api-object/manifest.json
+++ b/test/fixtures/detect-existing-browser-api-object/manifest.json
@@ -19,5 +19,7 @@
       ]
     }
   ],
-  "permissions": []
+  "permissions": [
+    "storage"
+  ]
 }

--- a/test/fixtures/detect-existing-browser-api-object/manifest.json
+++ b/test/fixtures/detect-existing-browser-api-object/manifest.json
@@ -6,11 +6,6 @@
   "background": {
     "page": "background.html"
   },
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "addon@example.com"
-    }
-  },
   "content_scripts": [
     {
       "matches": [

--- a/test/test-async-functions.js
+++ b/test/test-async-functions.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const {deepEqual, equal, fail, ok, throws} = require("chai").assert;
+const {deepEqual, equal, fail, ok, throws, instanceOf} = require("chai").assert;
 const sinon = require("sinon");
 
 const {setupTestDOMWindow} = require("./setup");
@@ -56,7 +56,7 @@ describe("browser-polyfill", () => {
     it("rejects the returned promise if chrome.runtime.lastError is not null", () => {
       const fakeChrome = {
         runtime: {
-          lastError: new Error("fake lastError"),
+          lastError: {message: "fake lastError"},
         },
         tabs: {
           query: sinon.stub(),
@@ -70,8 +70,11 @@ describe("browser-polyfill", () => {
 
         return window.browser.tabs.query({active: true}).then(
           () => fail("Expected a rejected promise"),
-          (err) => equal(err, fakeChrome.runtime.lastError,
-                         "Got the expected error in the rejected promise")
+          (err) => {
+            instanceOf(err, window.Error, "Expected the error to be an instance of Error");
+            equal(err.message, fakeChrome.runtime.lastError.message,
+                  "Got the expected error in the rejected promise");
+          }
         );
       });
     });


### PR DESCRIPTION
Same as #258, re-created to double-check if circle CI would run the CI job as expected. 

Fixes #257

Apart from cross-browser compatibility, this also follows this suggestion https://eslint.org/docs/rules/prefer-promise-reject-errors