### PR TITLE
Updating readme for typescript definitions and unit-testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ There are multiple projects that add TypeScript support to your web-extension pr
 
 | Project | Description |
 | ------------- | ------------- |
-| [webextension-polyfill-ts](https://github.com/Lusito/webextension-polyfill-ts) | Types and JS-Doc are automatically generated from the mozilla schema files, so it is always up-to-date with the latest APIs. It also bundles the webextension-polyfill for very simple usage. |
+| [@types/webextension-polyfill](https://www.npmjs.com/package/@types/webextension-polyfill) | Types and JS-Doc are automatically generated from the mozilla schema files, so it is always up-to-date with the latest APIs. Formerly known as [webextension-polyfill-ts](https://github.com/Lusito/webextension-polyfill-ts). |
 | [web-ext-types](https://github.com/kelseasy/web-ext-types) | Manually maintained types based on MDN's documentation. No JS-Doc included. |
 | [@types/chrome](https://www.npmjs.com/package/@types/chrome) | Manually maintained types and JS-Doc. Only contains types for chrome extensions though! |
 


### PR DESCRIPTION
- webextension-polyfill-ts is now [@types/webextension-polyfill](https://www.npmjs.com/package/@types/webextension-polyfill)
- Added a link to [mockzilla-webextension](https://lusito.github.io/mockzilla-webextension/), a unit-testing framework designed for web-extensions.