### PR TITLE
chore: Fix missing codecov reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,8 @@ commands:
       - run:
           name: run linting check and unit tests with coverage
           command: npm run test-coverage
+          environment:
+            COVERAGE_WITH_SOURCEMAP: "1"
       - store_artifacts:
           path: coverage
       - codecov/upload

--- a/test/setup.js
+++ b/test/setup.js
@@ -23,7 +23,7 @@ if (process.env.TEST_MINIFIED_POLYFILL) {
 
 function getInputSourceMap() {
   // Enabled only on CI until we have fixed the mapping to the source file
-  // (by making sure the babel generate a sourcemap that does also take into
+  // (by making sure that babel generates a sourcemap that does also take into
   // account the api metadata being interpolated into the src script).
   //
   // TODO(https://github.com/mozilla/webextension-polyfill/issues/348):

--- a/test/setup.js
+++ b/test/setup.js
@@ -21,6 +21,30 @@ if (process.env.TEST_MINIFIED_POLYFILL) {
   BROWSER_POLYFILL_PATH = process.env.TEST_BUNDLED_POLYFILL;
 }
 
+function getInputSourceMap() {
+  // Enabled only on CI until we have fixed the mapping to the source file
+  // (by making sure the babel generate a sourcemap that does also take into
+  // account the api metadata being interpolated into the src script).
+  //
+  // TODO(https://github.com/mozilla/webextension-polyfill/issues/348):
+  // disabling the sourcemapped code coverage will not be necessary anymore
+  // once we fix the generated sourcemap to correctly map to src/browser-polyfill.js
+  if (process.env.COVERAGE_WITH_SOURCEMAP != "1") {
+    return undefined;
+  }
+  if (process.env.TEST_BUNDLED_POLYFILL) {
+    // Running the unit tests on the bundled files are meant to be used as smoke tests,
+    // we don't need to collect code coverage for it.
+    throw new Error("Unexpected code coverage enabled while testing bundled modules");
+  }
+  let sourceMapPath = process.env.TEST_MINIFIED_POLYFILL
+    ? "./dist/browser-polyfill.js.min.map"
+    : "./dist/browser-polyfill.js.map";
+  let sourceMap = JSON.parse(fs.readFileSync(sourceMapPath, {encoding: "utf-8"}));
+  sourceMap.sources = ["../src/browser-polyfill.js"];
+  return sourceMap;
+}
+
 // Create the jsdom window used to run the tests
 const testDOMWindow = jsdom("", {virtualConsole}).defaultView;
 
@@ -71,7 +95,11 @@ function setupTestDOMWindow(chromeObject, browserObject = undefined) {
         compact: false, esModules: false, produceSourceMap: false,
       });
       const scriptContent = fs.readFileSync(BROWSER_POLYFILL_PATH, "utf-8");
-      scriptEl.textContent = inst.instrumentSync(scriptContent, BROWSER_POLYFILL_PATH);
+      scriptEl.textContent = inst.instrumentSync(
+        scriptContent,
+        BROWSER_POLYFILL_PATH,
+        getInputSourceMap()
+      );
     } else {
       scriptEl.src = BROWSER_POLYFILL_PATH;
     }


### PR DESCRIPTION
This PR includes an alternative approach to #344 

The resulting code coverage mapping is not yet right (in both this PR and #344), which is due to the fact that the sourcemap is generated by babel while converting the script into an UMD module, but after grunt-replace is used to interpolated the api-metadata.json data into the script.

I've verified locally that by manually replacing the content of api-metadata.json into the source file, than this PR does generate the expected mapping between the code coverage data collected and the original source file.

This PR is meant to be enough to ensure that codecov will detect and visibly report to us with a failure when a PR is decreasing the code coverage stats.

As a followup we could look into using babel to interpolate the api-metadata.json into the source file at an AST level using a custom babel plugin (specific to this project to keep it simple).

TODO:
- [x] verify codecov does add a code coverage comment as expected
- [x] verify that adding a fake commit that decrease the code coverage triggers a failure
- [x] file a follow up issue (#348) and link it into the inline comment added to test/setup.js   