### PR TITLE
Enable usage via `ProvidePlugin`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
   },
 
   "globals": {
+    "globalThis": true,
   },
 
   "rules": {

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -2,10 +2,13 @@
   "env": {
     "browser": true,
     "node": false,
-    "webextensions": true,
+    // Don't use `webextensions` because it enables the browser global.
+    // We want to use globalThis.browser instead:
+    // https://github.com/mozilla/webextension-polyfill/pull/351
   },
   "globals": {
     // Allow the `module` global, but not the `require(…)` function
     "module": false,
+    "chrome": true,
   },
 }

--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -6,11 +6,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-if (typeof window != "object" || typeof chrome != "object" || !chrome || !chrome.runtime || !chrome.runtime.id) {
+if (typeof globalThis != "object" || typeof chrome != "object" || !chrome || !chrome.runtime || !chrome.runtime.id) {
   throw new Error("This script should only be loaded in a browser extension.");
 }
 
-if (typeof window.browser === "undefined" || Object.getPrototypeOf(window.browser) !== Object.prototype) {
+if (typeof globalThis.browser === "undefined" || Object.getPrototypeOf(globalThis.browser) !== Object.prototype) {
   const CHROME_SEND_MESSAGE_CALLBACK_NO_RESPONSE_MESSAGE = "The message port closed before a response was received.";
   const SEND_RESPONSE_DEPRECATION_WARNING = "Returning a Promise is the preferred way to send a reply from an onMessage/onMessageExternal listener, as the sendResponse will be removed from the specs (See https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage)";
 

--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -6,7 +6,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-if (typeof browser === "undefined" || Object.getPrototypeOf(browser) !== Object.prototype) {
+if (typeof window != "object" || typeof chrome != "object" || !chrome || !chrome.runtime || !chrome.runtime.id) {
+  throw new Error("This script should only be loaded in a browser extension.");
+}
+
+if (typeof window.browser === "undefined" || Object.getPrototypeOf(window.browser) !== Object.prototype) {
   const CHROME_SEND_MESSAGE_CALLBACK_NO_RESPONSE_MESSAGE = "The message port closed before a response was received.";
   const SEND_RESPONSE_DEPRECATION_WARNING = "Returning a Promise is the preferred way to send a reply from an onMessage/onMessageExternal listener, as the sendResponse will be removed from the specs (See https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage)";
 
@@ -539,10 +543,6 @@ if (typeof browser === "undefined" || Object.getPrototypeOf(browser) !== Object.
 
     return wrapObject(extensionAPIs, staticWrappers, apiMetadata);
   };
-
-  if (typeof chrome != "object" || !chrome || !chrome.runtime || !chrome.runtime.id) {
-    throw new Error("This script should only be loaded in a browser extension.");
-  }
 
   // The build process adds a UMD wrapper around this file, which makes the
   // `module` variable available.

--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -548,5 +548,5 @@ if (typeof globalThis.browser === "undefined" || Object.getPrototypeOf(globalThi
   // `module` variable available.
   module.exports = wrapAPIs(chrome);
 } else {
-  module.exports = browser;
+  module.exports = globalThis.browser;
 }


### PR DESCRIPTION
- Actually fixes https://github.com/mozilla/webextension-polyfill/issues/156

Rereading [my last attempt](https://github.com/webpack/webpack/issues/6226#issuecomment-720622514) at dissuading webpack developers to fix ProvidePlugin’s awkward self-providing behavior, I realized that there must be a way to fool webpack into ignoring this replacement.


```js
plugins: [
  new ProvidePlugin({
    browser: "webextension-polyfill"
  })
]
```

ProvidePlugin looks for the raw `browser` variable and replaces it; Turning it into a `window` property access should break it — if not, `typeof window["brow" + "ser"]` certainly will.

This change should be non-breaking, as an alternative solution to https://github.com/mozilla/webextension-polyfill/issues/350 — rather, as a stopgap solution to it.