### PR TITLE
Lint: Enforce quotes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -415,7 +415,7 @@
     "quote-props": 0,
 
     // Double quotes should be used.
-    "quotes": [1, "double", {"avoidEscape": true, "allowTemplateLiterals": true}],
+    "quotes": [2, "double", {"avoidEscape": true, "allowTemplateLiterals": true}],
 
     // Require use of the second argument for parseInt().
     "radix": 2,

--- a/test/fixtures/detect-existing-browser-api-object/content.js
+++ b/test/fixtures/detect-existing-browser-api-object/content.js
@@ -37,18 +37,18 @@ test("browser api object in background page", async (t) => {
 test("error types", async (t) => {
   if (navigator.userAgent.includes("Firefox/")) {
     try {
-      await browser.storage.sync.set({a: 'a'});
-      t.fail('It should throw when attempting to call storage.sync with a temporary addon ID');
+      await browser.storage.sync.set({a: "a"});
+      t.fail("It should throw when attempting to call storage.sync with a temporary addon ID");
     } catch (error) {
-      t.equal(error.message, 'The storage API will not work with a temporary addon ID. Please add an explicit addon ID to your manifest. For more information see https://mzl.la/3lPk1aE.');
+      t.equal(error.message, "The storage API will not work with a temporary addon ID. Please add an explicit addon ID to your manifest. For more information see https://mzl.la/3lPk1aE.");
       t.ok(error instanceof Error);
     }
   } else {
     await new Promise(resolve => {
-      chrome.storage.local.set({a: 'a'.repeat(10000000)}, resolve);
+      chrome.storage.local.set({a: "a".repeat(10000000)}, resolve);
     });
-    t.ok(chrome.runtime.lastError, 'It should throw when attempting to set an object over quota');
-    t.equal(chrome.runtime.lastError.message, 'QUOTA_BYTES quota exceeded');
+    t.ok(chrome.runtime.lastError, "It should throw when attempting to set an object over quota");
+    t.equal(chrome.runtime.lastError.message, "QUOTA_BYTES quota exceeded");
     t.notOk(chrome.runtime.lastError instanceof Error);
   }
 });


### PR DESCRIPTION
If there's a lint, follow it and enforce it, otherwise it just adds noise.

## Before

```
❯ grunt eslint
Running "eslint:src" (eslint) task


Running "eslint:test" (eslint) task

./test/fixtures/detect-existing-browser-api-object/content.js
  40:42  warning  Strings must use doublequote  quotes
  41:14  warning  Strings must use doublequote  quotes
  43:30  warning  Strings must use doublequote  quotes
  48:36  warning  Strings must use doublequote  quotes
  50:36  warning  Strings must use doublequote  quotes
  51:47  warning  Strings must use doublequote  quotes

✖ 6 problems (0 errors, 6 warnings)
  0 errors and 6 warnings potentially fixable with the `--fix` option.


Done.
```

## After

```
grunt eslint
Running "eslint:src" (eslint) task


Running "eslint:test" (eslint) task


Done.
```