### PR TITLE
chore: Run `apt update` before installing xserver-xephyr in the CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ commands:
     description: run Xephyr on DISPLAY=:10
     steps:
       - run: |
+          sudo apt update
           sudo apt install xserver-xephyr
           Xephyr -ac -br -noreset -screen 1280x1024x24 :10 &
           sleep 2


### PR DESCRIPTION
CI job are currently failure the setup part of the integration tests, when we are installing xserver-xephyr from API, e.g.:
- https://app.circleci.com/pipelines/github/mozilla/webextension-polyfill/309/workflows/6e9354f7-00ac-481f-8ee4-775297bc1701/jobs/319/parallel-runs/0/steps/0-115

The error seems to suggest that the apt packages list may be outdated, this PR calls `apt update` right before `apt install` to confirm if that is actually the case. 