### PR TITLE
chore(ci): Updated circleci to use the new cimg/node docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,9 @@ orbs:
   codecov: codecov/codecov@3.2.2
 
 references:
-  nodejs_current: &nodejs_current "12"
+  # See https://hub.docker.com/r/cimg/node/tags for the nodejs versions
+  # available.
+  nodejs_current: &nodejs_current "12.22"
   repo_path: &repo_path ~/webextension-polyfill
   defaults: &defaults
     working_directory: *repo_path
@@ -131,7 +133,7 @@ jobs:
     <<: *defaults
     docker:
       # Image variant including Firefox, Chrome and Xvfb
-      - image: circleci/node:<< parameters.nodejs_current >>-browsers
+      - image: cimg/node:<< parameters.nodejs_current >>-browsers
     steps:
       - attach_project_repo
       - checkout
@@ -144,7 +146,7 @@ jobs:
   release-tag:
     <<: *defaults
     docker:
-      - image: circleci/node:<< parameters.nodejs_current >>
+      - image: cimg/node:<< parameters.nodejs_current >>
     steps:
       - attach_project_repo
       - run_npm_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ orbs:
 references:
   # See https://hub.docker.com/r/cimg/node/tags for the nodejs versions
   # available.
+  #
+  # TODO: not listing the docker image explicitly is likely to prevent
+  # renovatebot from being able to automatically create PRs to update it.
   nodejs_current: &nodejs_current "12.22"
   repo_path: &repo_path ~/webextension-polyfill
   defaults: &defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,7 @@ jobs:
       # Image variant including Firefox, Chrome and Xvfb
       - image: cimg/node:<< parameters.nodejs_current >>-browsers
     steps:
+      - browser-tools/install-browser-tools
       - attach_project_repo
       - checkout
       - run_npm_install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ version: 2.1
 
 orbs:
   codecov: codecov/codecov@3.2.2
+  browser-tools: circleci/browser-tools@1.1.0
 
 references:
   # See https://hub.docker.com/r/cimg/node/tags for the nodejs versions

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-minify": "0.5.1",
     "browserify": "17.0.0",
     "chai": "4.3.4",
-    "chromedriver": "96.0.0",
+    "chromedriver": "99.0.0",
     "cross-env": "7.0.3",
     "eslint": "7.25.0",
     "finalhandler": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cross-env": "7.0.3",
     "eslint": "7.25.0",
     "finalhandler": "1.1.2",
-    "geckodriver": "1.22.3",
+    "geckodriver": "3.0.1",
     "global-replaceify": "1.0.0",
     "grunt": "1.4.0",
     "grunt-babel": "8.0.0",


### PR DESCRIPTION
- migrate to the cimg/node docker image
- added (and invoked) the circleci/browser-tools-org (needed to be able to run the integration tests on Firefox and Chrome)
- update chromedriver to v99 and geckodriver to v3 (to make sure they will support also more recent version of Firefox and Chrome)

Filed also a followup for further changes to the circleci config if renovatebot is unable to detect updates needed to the cimg/node docker images with the yaml config as is.