### PR TITLE
Optionally allow polyfilling the browser global even when used with a bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ browser.runtime.onMessage.addListener(...);
 
 This library is built as a **UMD module** (Universal Module Definition), and so it can also be used with module bundlers (and explicitly tested on both **webpack** and **browserify**) or AMD module loaders.
 
+Be aware that when used with module bundlers, the polyfill module does not define the `browser` object in the global namespace (i.e. `window`), but is only available in the file that imports it. To define the `browser` object  globally, [import the `register` file](#Polyfilling-the-browser-global-with-module-bundlers) instead.
+
 **src/background.js**:
 ```javascript
 var browser = require("webextension-polyfill");
@@ -185,6 +187,18 @@ If the extension doesn't minify its own sources, it is still possible to explici
 var browser = require("webextension-polyfill/dist/browser-polyfill.min");
 
 ...
+```
+
+### Polyfilling the `browser` global with module bundlers
+
+If you prefer importing the polyfill once in your entry point when using webpack or other bundlers:
+
+**src/background.js**:
+```javascript
+require("webextension-polyfill/register");
+
+// The `browser` object will now be available everywhere in the background page
+console.log(browser.runtime.id);
 ```
 
 ### Usage with webpack without bundling

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A lightweight polyfill library for Promise-based WebExtension APIs in Chrome.",
   "main": "dist/browser-polyfill.js",
   "files": [
-    "dist"
+    "dist",
+    "register.js"
   ],
   "repository": {
     "type": "git",

--- a/register.js
+++ b/register.js
@@ -1,1 +1,1 @@
-globalThis.browser = require('webextension-polyfill');
+globalThis.browser = require('./dist/browser-polyfill.js');

--- a/register.js
+++ b/register.js
@@ -1,0 +1,1 @@
+globalThis.browser = require('webextension-polyfill');


### PR DESCRIPTION
- Fixes #350 

I think this file solves the issue in an extremely lightweight, non-breaking, trouble-free way:

- the existing bundle is not affected
- it's opt-in, easily
- if a project imports `webextension-polyfill/register` and `webextension-polyfill` separately, it will _not_ be bundled twice
- it follows the [conventional naming](https://babeljs.io/docs/en/babel-register/) for imports that affect globals in Node: `register`
- it matches exactly what users must currently do to set the `browser` global with a bundler

### Benefits of having this file here

- I don't have to create the same file in every project I use
- it lets you safely polyfill the global without falling into this trap:

	```js 
	import browser from "webextension-polyfill"
	window.browser = browser;

	import other from "module-that-expects-browser-global"
	```

	One would think that by the 4th line, `window.browser` will be set, but in reality all dependencies are loaded/run before the current file is executed, so `window.browser` is undefined in `"module-that-expects-browser-global"`. This is not common knowledge and it leads to frustration.

	This instead works flawlessly:

	
	```js 
	import "webextension-polyfill/register"
	import other from "module-that-expects-browser-global"
	```

### Note about ESM (and lack thereof)

This file is meant to be used exclusively with bundlers, so `require` is fine here (and it actually matches the UMD it's already using)

### Relation to https://github.com/mozilla/webextension-polyfill/pull/351

This offers an alternative way of using the polyfill:

- explicitly via `import "webextension-polyfill/register"`
- automatically via `ProvidePlugin`

Note that `ProvidePlugin` is Webpack-only so its support does not preclude this new usage, which is actually why I'm submitting this PR.

### To do after approval

- [x] update the documentation