### PR TITLE
Use optional chaining to simplify the detection code

### DIFF
--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -10,7 +10,7 @@ if (!globalThis.chrome?.runtime?.id) {
   throw new Error("This script should only be loaded in a browser extension.");
 }
 
-if (!globalThis.browser?.runtime?.id || Object.getPrototypeOf(globalThis.browser) !== Object.prototype) {
+if (typeof globalThis.browser === "undefined" || Object.getPrototypeOf(globalThis.browser) !== Object.prototype) {
   const CHROME_SEND_MESSAGE_CALLBACK_NO_RESPONSE_MESSAGE = "The message port closed before a response was received.";
   const SEND_RESPONSE_DEPRECATION_WARNING = "Returning a Promise is the preferred way to send a reply from an onMessage/onMessageExternal listener, as the sendResponse will be removed from the specs (See https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage)";
 

--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -10,7 +10,7 @@ if (!globalThis.chrome?.runtime?.id) {
   throw new Error("This script should only be loaded in a browser extension.");
 }
 
-if (!globalThis.browser?.runtime?.id) {
+if (!globalThis.browser?.runtime?.id || Object.getPrototypeOf(globalThis.browser) !== Object.prototype) {
   const CHROME_SEND_MESSAGE_CALLBACK_NO_RESPONSE_MESSAGE = "The message port closed before a response was received.";
   const SEND_RESPONSE_DEPRECATION_WARNING = "Returning a Promise is the preferred way to send a reply from an onMessage/onMessageExternal listener, as the sendResponse will be removed from the specs (See https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage)";
 

--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -6,11 +6,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-if (typeof globalThis != "object" || typeof chrome != "object" || !chrome || !chrome.runtime || !chrome.runtime.id) {
+if (!globalThis.chrome?.runtime?.id) {
   throw new Error("This script should only be loaded in a browser extension.");
 }
 
-if (typeof globalThis.browser === "undefined" || Object.getPrototypeOf(globalThis.browser) !== Object.prototype) {
+if (!globalThis.browser?.runtime?.id) {
   const CHROME_SEND_MESSAGE_CALLBACK_NO_RESPONSE_MESSAGE = "The message port closed before a response was received.";
   const SEND_RESPONSE_DEPRECATION_WARNING = "Returning a Promise is the preferred way to send a reply from an onMessage/onMessageExternal listener, as the sendResponse will be removed from the specs (See https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage)";
 


### PR DESCRIPTION
Mini proposal to simplify the detection code. Feel free to reject it if the drawbacks are too great.

## Pros

- Readable code
- ES2020, yo

## Cons

- It breaks pre-ES2020 build pipelines unless you add a babel transform for it (but I think `babel/preset-env` should already cover it 🤔) and transpile it down