### PR TITLE
feat: support mv3 scripting api

### DIFF
--- a/api-metadata.json
+++ b/api-metadata.json
@@ -453,6 +453,36 @@
       "maxArgs": 1
     }
   },
+  "scripting": {
+    "executeScript": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "getRegisteredContentScripts": {
+      "minArgs": 0,
+      "maxArgs": 1
+    },
+    "insertCSS": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "registerContentScripts": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "removeCSS": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "updateContentScripts": {
+      "minArgs": 1,
+      "maxArgs": 1
+    },
+    "unregisterContentScripts": {
+      "minArgs": 0,
+      "maxArgs": 1
+    }
+  },
   "sessions": {
     "getDevices": {
       "minArgs": 0,


### PR DESCRIPTION
As mentioned in https://github.com/mozilla/webextension-polyfill/issues/382  It seems like [MV3 scripting API](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting) is not available yet. 

## What is included
- Added `scripting.executeScript`, `scripting.getRegisteredContentScripts`, `scripting.insertCSS`, `scripting.registerContentScripts`, `scripting.removeCSS`, `scripting.updateContentScripts` and `scripting.unregisterContentScripts` APIs to `api-metadata.json`.

## What is missing
- Tests? Not yet sure which tests would make sense here (Any pointers?)