### PR TITLE
chore(deps): removed tap-nirvana from the dev dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,12 +77,7 @@ or
 TEST_BROWSER_TYPE=firefox npm run test-integration
 ```
 
-These tests emit their results using the TAP protocol. To get a nicer output on the console 
-you may want to pipe the results to `tap-nirvana`, e.g.
-
-```sh
-TEST_BROWSER_TYPE=chrome npm run test-integration | ./node_modules/.bin/tap-nirvana
-```
+These tests emit their results using the TAP protocol.
 
 ## Writing commit messages
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "serve-static": "1.15.0",
     "shelljs": "0.8.5",
     "sinon": "14.0.0",
-    "tap-nirvana": "1.1.0",
     "tape": "5.5.3",
     "tape-async": "2.3.0",
     "tmp": "0.2.1"
@@ -63,7 +62,7 @@
     "test-coverage": "cross-env COVERAGE=y nyc mocha",
     "test-minified": "cross-env TEST_MINIFIED_POLYFILL=1 mocha",
     "test-integration": "tape test/integration/test-*",
-    "test-integration:chrome": "cross-env TEST_BROWSER_TYPE=chrome npm run test-integration | tap-nirvana",
-    "test-integration:firefox": "cross-env TEST_BROWSER_TYPE=firefox npm run test-integration | tap-nirvana"
+    "test-integration:chrome": "cross-env TEST_BROWSER_TYPE=chrome npm run test-integration",
+    "test-integration:firefox": "cross-env TEST_BROWSER_TYPE=firefox npm run test-integration"
   }
 }


### PR DESCRIPTION
tap-nirvana doesn't seem to be mantained and one of its dependency has a security advisor and it seems to be pinned in tap-nirvana dependency.

It would be nice to replace it with an alternative tap protocol formatter, there is tap-mocha-reporter which looks like a good candidate, but that unfortunately requires some more work to get a nice output and don't lose any of the details that tap-nirvana.

In the meantime tape default output will still provide all details to investigate failures, and it is still readable (just not nicely formatted).