### PR TITLE
Fix support of old browsers

### DIFF
--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-if (!globalThis.chrome?.runtime?.id) {
+if (typeof globalThis != "object" || typeof chrome != "object" || !chrome || !chrome.runtime || !chrome.runtime.id) {
   throw new Error("This script should only be loaded in a browser extension.");
 }
 


### PR DESCRIPTION
Optional chaining operators are supported starting from the 80 version
https://caniuse.com/mdn-javascript_operators_optional_chaining
In readme is stated support for 79 version. Lets remove optional chaining operator.