### PR TITLE
Fix no-op check to work with Safari and support of old browsers

### DIFF
--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -6,11 +6,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 "use strict";
 
-if (!globalThis.chrome?.runtime?.id) {
+if (!(globalThis.chrome && globalThis.chrome.runtime && globalThis.chrome.runtime.id)) {
   throw new Error("This script should only be loaded in a browser extension.");
 }
 
-if (typeof globalThis.browser === "undefined" || Object.getPrototypeOf(globalThis.browser) !== Object.prototype) {
+if (!(globalThis.browser && globalThis.browser.runtime && globalThis.browser.runtime.id)) {
   const CHROME_SEND_MESSAGE_CALLBACK_NO_RESPONSE_MESSAGE = "The message port closed before a response was received.";
 
   // Wrapping the bulk of this polyfill in a one-time-use function is a minor


### PR DESCRIPTION
The `browser` object is not a direct descendant of `Object.prototype` in Safari. This check should use `instanceof` for a more compatible check.