### PR TITLE
chore: chromedriver and geckodriver dependencies along with circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,13 @@
 #
 # - to try run jobs locally:
 #
-#     circleci config process .circleci/config.yml > tmp/processed.yml
-#     circleci local execute -c tmp/processed.yml --job build-nodejs-current
+#     circleci local execute -c .circleci/config.yml build-nodejs-current
 #
 version: 2.1
 
 orbs:
   codecov: codecov/codecov@3.2.3
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.8
 
 references:
   working_directory: &working_directory ~/webextension-polyfill
@@ -26,14 +25,14 @@ references:
     # See https://hub.docker.com/r/cimg/node/tags for the cimg/node tags
     # related to specific nodejs versions.
     docker:
-      - image: cimg/node:14.19
+      - image: cimg/node:20.12
 
   defaults-browsers: &defaults-browsers
     <<: *defaults
     # Image variant (combined with circleci/browser-tools orb) used to
     # run integration tests using Firefox, Chrome and Xvfb.
     docker:
-      - image: cimg/node:14.19-browsers
+      - image: cimg/node:20.12-browsers
 
 
 commands:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-minify": "0.5.2",
     "browserify": "17.0.0",
     "chai": "4.3.6",
-    "chromedriver": "112.0.0",
+    "chromedriver": "123.0.3",
     "cross-env": "7.0.3",
     "eslint": "8.35.0",
     "finalhandler": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cross-env": "7.0.3",
     "eslint": "8.35.0",
     "finalhandler": "1.2.0",
-    "geckodriver": "3.2.0",
+    "geckodriver": "4.3.3",
     "global-replaceify": "1.0.0",
     "grunt": "1.6.1",
     "grunt-babel": "8.0.0",

--- a/test/test-browser-global.js
+++ b/test/test-browser-global.js
@@ -28,7 +28,7 @@ describe("browser-polyfill", () => {
       runtime: {lastError: null},
     };
     const fakeBrowser = {
-      mycustomns: {mybrowserkey: true},
+      runtime: {id: "fakeid"},
     };
 
     return setupTestDOMWindow(fakeChrome, fakeBrowser).then(window => {


### PR DESCRIPTION
This PR includes a set of changes needed to fix the CI job failures currently hit due to mismatch between the Chrome version installed in the CI jobs and the Chrome versions supported by the chromedriver dev dependencies (and so it supersedes also PR #573).

Along with that change this PR is also:
- updating the nodejs version used in the CI jobs (from node 14 to node 20)
- fixing a unit test to match the new expected behavior with the changes applied from #582
- updating the inline comment that mention the circleci cli command to use to run the CI job locally on docker (updated to the command line options expected by more recent version of the circleci cli tool)
- updating the geckodriver dependency (from 3.2.0 to 4.3.3, and so this PR also supersedes PR #541)