### PR TITLE
chore: drop -g from npm install in ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,9 @@ commands:
   run_test_bundlers:
     description: rerun unit tests on webpack and browserify bundled files
     steps:
-      - run: npm install -g browserify webpack webpack-cli
+      - run: npm install browserify webpack webpack-cli
       - run: |
-          export PATH=$PATH:../.npm-global/bin
+          export PATH=$PATH:$PWD/node_modules/.bin
           node ./scripts/run-module-bundlers-smoketests.js
 
   run_xephyr:


### PR DESCRIPTION
After bumping the version directly on master, CI failed unexpectedly: https://github.com/mozilla/webextension-polyfill/commit/af051ff258168f29d823462eb8dcf906752336ca

This is likely due to an image bump in https://github.com/mozilla/webextension-polyfill/commit/338d75f9cb8c8a5311de295aa27da558df750a0b . Previously `npm i -g` installed to `~/.npm-global`, possibly because the image was built after following the instructions from https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally#manually-change-npms-default-directory . The latest CI image does not have this override though, which causes `npm i -g` to fail with `EACCES: permission denied, mkdir '/usr/local/lib/node_modules/browserify'`.