### PR TITLE
fix: Remove webpack and webpack-cli dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,10 +63,7 @@ commands:
   run_test_bundlers:
     description: rerun unit tests on webpack and browserify bundled files
     steps:
-      - run: npm install browserify webpack webpack-cli
-      - run: |
-          export PATH=$PATH:$PWD/node_modules/.bin
-          node ./scripts/run-module-bundlers-smoketests.js
+      - run: npm run test-module-bundlers-smoketests
 
   run_xephyr:
     description: run Xephyr on DISPLAY=:10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ respectively, and finally execute the unit tests on the generated dist files.
 This project provides two test suites:
 
 - unit tests (which only require Node.js to run)
-- module bundlers smoke tests (which requires also browserify and webpack to be installed globally)
+- module bundlers smoke tests
 - integration tests (which requires also a stable version of Chrome and Firefox)
 
 ### Unit Tests
@@ -51,8 +51,8 @@ by running `npm run test-coverage`.
 
 ### Module Bundler smoketests
 
-The shell script `test/run-module-bundlers-smoketests.sh` runs browserify and webpack, 
-to verify that the most commonly used module bundlers are not raising any unexpected error 
+`npm run test-module-bundlers-smoketests` runs browserify and webpack,
+to verify that the most commonly used module bundlers are not raising any unexpected error
 while building a bundle that requires this library.
 
 ### Integration Tests

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "homepage": "https://github.com/mozilla/webextension-polyfill",
   "devDependencies": {
     "@babel/core": "7.18.10",
+    "@babel/eslint-parser": "7.19.1",
     "@babel/preset-env": "7.18.10",
     "@babel/register": "7.18.9",
-    "@babel/eslint-parser": "7.19.1",
     "babel-preset-minify": "0.5.2",
     "browserify": "17.0.0",
     "chai": "4.3.6",
@@ -44,7 +44,9 @@
     "sinon": "14.0.0",
     "tape": "5.5.3",
     "tape-async": "2.3.0",
-    "tmp": "0.2.1"
+    "tmp": "0.2.1",
+    "webpack": "5.91.0",
+    "webpack-cli": "5.1.4"
   },
   "nyc": {
     "reporter": [
@@ -63,6 +65,7 @@
     "test-minified": "cross-env TEST_MINIFIED_POLYFILL=1 mocha",
     "test-integration": "tape test/integration/test-*",
     "test-integration:chrome": "cross-env TEST_BROWSER_TYPE=chrome npm run test-integration",
-    "test-integration:firefox": "cross-env TEST_BROWSER_TYPE=firefox npm run test-integration"
+    "test-integration:firefox": "cross-env TEST_BROWSER_TYPE=firefox npm run test-integration",
+    "test-module-bundlers-smoketests": "./scripts/run-module-bundlers-smoketests.js"
   }
 }


### PR DESCRIPTION
Changes made in #597 accidentally resulted in `webpack` and `webpack-cli` being added as dependencies in the manifest of the published package. This problem can be seen in v0.11.0. For more information, see #604.

`webpack` and `webpack-cli` are used for bundler smoke tests that are run in CI. Rather than being installed during CI, these dependencies are now included in `devDependencies`. A new npm script has been added for running this script as well, to ensure that these dependencies are on the PATH when this script is run.

The CircleCI config and the contributor docs have been updated to use the new npm script. You can test it by running
`npm run test-module-bundlers-smoketest`.

Fixes #604