### PR TITLE
fix: Errors from asynchronous API calls have incomplete stack traces

### DIFF
--- a/src/browser-polyfill.js
+++ b/src/browser-polyfill.js
@@ -96,9 +96,14 @@ if (!(globalThis.browser && globalThis.browser.runtime && globalThis.browser.run
      *        The generated callback function.
      */
     const makeCallback = (promise, metadata) => {
+      // In case we encounter a browser error in the callback function, we don't
+      // want to lose the stack trace leading up to this point. For that reason,
+      // we need to instantiate the error outside the callback function.
+      let error = new Error();
       return (...callbackArgs) => {
         if (extensionAPIs.runtime.lastError) {
-          promise.reject(new Error(extensionAPIs.runtime.lastError.message));
+          error.message = extensionAPIs.runtime.lastError.message;
+          promise.reject(error);
         } else if (metadata.singleCallbackArg ||
                    (callbackArgs.length <= 1 && metadata.singleCallbackArg !== false)) {
           promise.resolve(callbackArgs[0]);


### PR DESCRIPTION
We've been observing various browser errors in the Adblock Plus extension that the browser exposes via `browser.runtime.lastError`. Unfortunately, the stack traces of those errors terminate at webextension-polyfill (in its callback function that handles `browser.runtime.lastError`) and therefore don't provide any further information to the extension about which of its API calls led to the error.

e.g. `browser.action.setBadgeText({tabId: 123, text: ""})`

This pull request contains the following changes to provide a more useful/complete stack trace for such browser errors:
- Added a new error object to capture the stack trace leading up to an asynchronous API call.\
  _Error message is based on MDN's description of `browser.runtime.lastError`._
- Assign `browser.runtime.lastError` as message to the new error object.
- Updated tests accordingly.

Since the `Error`s "cause" property isn't widely supported yet, overwriting the error's "message" property seems to be next-best approach in order to avoid merging stack traces, as that can get messy. That being said, I acknowledge that this is merely a workaround, and that any approach that allows us to natively retain the full stack trace across such asynchronous API calls should be preferable.