### PR TITLE
chore: update circleci/browser-tools orb to version 1.5.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ version: 2.1
 
 orbs:
   codecov: codecov/codecov@3.2.3
-  browser-tools: circleci/browser-tools@1.4.8
+  browser-tools: circleci/browser-tools@1.5.3
 
 references:
   working_directory: &working_directory ~/webextension-polyfill

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-minify": "0.5.2",
     "browserify": "17.0.0",
     "chai": "5.1.1",
-    "chromedriver": "129.0.0",
+    "chromedriver": "134.0.5",
     "cross-env": "7.0.3",
     "eslint": "9.11.1",
     "finalhandler": "1.3.1",


### PR DESCRIPTION
This PR updates circleci/browser-tools orb to version 1.5.3, there is an unexpected issue hit by recently created (e.g. like this [one](https://app.circleci.com/pipelines/github/mozilla/webextension-polyfill/1108/workflows/e7e42056-c874-452b-8912-ed8892ea1011/jobs/1128)) that may be due to this.