### PR TITLE
fix(security): update tmp to resolve symlink vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chai": "5.1.1",
     "chromedriver": "134.0.5",
     "cross-env": "7.0.3",
-    "eslint": "9.11.1",
+    "eslint": "9.39.3",
     "finalhandler": "1.3.1",
     "geckodriver": "4.4.4",
     "global-replaceify": "1.0.0",
@@ -45,7 +45,7 @@
     "sinon": "19.0.2",
     "tape": "5.9.0",
     "tape-async": "2.3.0",
-    "tmp": "0.2.3",
+    "tmp": "0.2.5",
     "webpack": "5.95.0",
     "webpack-cli": "5.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chai": "5.1.1",
     "chromedriver": "134.0.5",
     "cross-env": "7.0.3",
-    "eslint": "9.39.3",
+    "eslint": "9.11.1",
     "finalhandler": "1.3.1",
     "geckodriver": "4.4.4",
     "global-replaceify": "1.0.0",


### PR DESCRIPTION
## Summary

Bump `tmp` from 0.2.3 to 0.2.5 to resolve:
- **GHSA-52f5-9888-hmc6**: arbitrary file/directory write via symbolic link attack

This is a semver-compatible patch update affecting only devDependencies.

## Changes
- `tmp`: 0.2.3 → 0.2.5 (security fix for symlink vulnerability)

## Test plan
- All existing tests, linting, and builds should pass unchanged
- Only the `tmp` package version changes; no code modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)